### PR TITLE
[Feat/#278] LoginPopup 컴포넌트 구현

### DIFF
--- a/src/asset/svg/IcChevronRight.tsx
+++ b/src/asset/svg/IcChevronRight.tsx
@@ -1,14 +1,9 @@
 import * as React from "react";
 import type { SVGProps } from "react";
 const SvgIcChevronRight = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 29 29"
-    {...props}
-  >
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 29 29" {...props}>
     <path
-      stroke="#222"
+      stroke={props.stroke || "#222"}
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={1.5}

--- a/src/shared/component/LoginPopup/LoginPopup.css.ts
+++ b/src/shared/component/LoginPopup/LoginPopup.css.ts
@@ -1,0 +1,31 @@
+import { font, semanticColor } from "@style/styles.css";
+import { style } from "@vanilla-extract/css";
+
+export const loginPopupContainer = style({
+  display: "flex",
+  flexDirection: "row",
+  padding: "1.2rem 2.8rem",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "0.6rem",
+
+  width: "23rem",
+  height: "4.4rem",
+
+  position: "fixed",
+  bottom: "9.6rem",
+  left: "50%",
+  transform: "translateX(-50%)",
+
+  borderRadius: "0.8rem",
+  background: semanticColor.primary.strong,
+  boxShadow: "0px 2px 10px 0px rgba(0, 0, 0, 0.15)",
+});
+
+export const loginPopupText = style([
+  {
+    color: semanticColor.text.inverse,
+    whiteSpace: "nowrap",
+  },
+  font.body01,
+]);

--- a/src/shared/component/LoginPopup/LoginPopup.tsx
+++ b/src/shared/component/LoginPopup/LoginPopup.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import * as styles from "./LoginPopup.css";
+import { IcChevronRight } from "@asset/svg";
+
+interface LoginPopupProps {
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+export const LoginPopup = ({ isOpen, onClick }: LoginPopupProps) => {
+  return (
+    <div className={styles.loginPopupContainer} onClick={onClick}>
+      <span className={styles.loginPopupText}>로그인 하고 리뷰 확인하기</span>
+      <IcChevronRight width={20} height={20} stroke="#fff" />
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔥 Related Issues

- close #278 

## ✅ 작업 리스트

- [x] shared 컴포넌트인 LoginPopup 구현

## 🔧 작업 내용
사용하실 곳 아무곳에나 해당 컴포넌트 써서 사용하시면 됩니다 ~
isOpen으로 보여줄지 여부 결정하시면 되고, onClick으로 클릭시 실행할 함수 연결하면 끝!

```
<LoginPopup
    isOpen={true}
    onClick={() => {
      alert("로그인 후 이용해주세요.");
    }}
  />
```


## 📣 리뷰어에게 어떠신가요?

## 📸 스크린샷 / GIF / Link
<img width="377" alt="image" src="https://github.com/user-attachments/assets/410a4752-f69a-47bd-a8df-43376d75d506" />

