### PR TITLE
[Feat/#287] 리뷰작성 2페이지

### DIFF
--- a/public/svgs/ic_reviewRightIcon.svg
+++ b/public/svgs/ic_reviewRightIcon.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Right Icon">
+<path id="Icon" d="M14.1668 5.8335L5.8335 14.1668M5.8335 5.8335L14.1668 14.1668" stroke="#3DC4F5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/api/constants/apiPath.ts
+++ b/src/api/constants/apiPath.ts
@@ -24,4 +24,6 @@ export const API_PATH = {
 
   TEST_HEALTH_CHECK: "/api/dev/test/health-check",
   TEST_TOKEN_CHECK: "/api/dev/test/token-check",
+
+  HOSPITALS_PURPOSE: "/api/dev/hospitals/purposes"
 };

--- a/src/app/api/review/write/hook.ts
+++ b/src/app/api/review/write/hook.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPurpose } from "@app/api/review/write";
+
+export const usePurposeGet = () => {
+  return useQuery({
+    queryKey: ["purpose"],
+    queryFn: () => {
+      return getPurpose();
+    },
+  });
+};

--- a/src/app/api/review/write/index.ts
+++ b/src/app/api/review/write/index.ts
@@ -1,0 +1,10 @@
+import { paths } from "@type/schema";
+import { API_PATH } from "@api/constants/apiPath";
+import { get } from "@api/index";
+
+export type purposeGetResponse = paths["/api/dev/hospitals/purposes"]["get"]["responses"]["200"]["content"]["*/*"];
+
+export const getPurpose = async () => {
+  const { data } = await get<purposeGetResponse>(API_PATH.HOSPITALS_PURPOSE, {});
+  return data.data;
+};

--- a/src/app/review/write/_component/BtnToChip.style.css.ts
+++ b/src/app/review/write/_component/BtnToChip.style.css.ts
@@ -1,0 +1,44 @@
+import { recipe } from "@vanilla-extract/recipes";
+import { style } from "@vanilla-extract/css";
+
+import { color, font } from "@style/styles.css";
+
+export const wrapper = recipe({
+  base: [
+    font.heading03,
+    {
+      display: "flex",
+      alignContent: "center",
+      justifyContent: "space-between",
+      width: "100%",
+      padding: "1.2rem",
+      alignItems: "center",
+
+      borderRadius: "8px",
+      backgroundColor: color.gray.gray000,
+    },
+  ],
+  variants: {
+    selected: {
+      false: {
+        color: color.gray.gray500,
+        border: `1px solid ${color.gray.gray200}`,
+      },
+      true: {
+        color: color.primary.blue700,
+        border: `1px solid ${color.primary.blue500}`,
+      },
+    },
+  },
+});
+
+export const buttonText = style({
+  display: "flex",
+  justifyContent: "space-between",
+  width: "100%",
+});
+
+export const icon = style({
+  width: 20,
+  height: 20,
+});

--- a/src/app/review/write/_component/BtnToChip.tsx
+++ b/src/app/review/write/_component/BtnToChip.tsx
@@ -1,0 +1,19 @@
+import * as styles from "./BtnToChip.style.css";
+
+interface BtnToChipProps {
+  label?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  rightIcon?: React.ReactNode;
+}
+
+const BtnToChip = ({ label = "BtnToChip", onClick, rightIcon }: BtnToChipProps) => {
+  return (
+    <button onClick={onClick} className={styles.wrapper({ selected: false })}>
+      <span className={styles.buttonText}>
+        {label} {rightIcon && <div className={styles.icon}>{rightIcon}</div>}
+      </span>
+    </button>
+  );
+};
+
+export default BtnToChip;

--- a/src/app/review/write/_component/BtnToChip.tsx
+++ b/src/app/review/write/_component/BtnToChip.tsx
@@ -4,11 +4,12 @@ interface BtnToChipProps {
   label?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   rightIcon?: React.ReactNode;
+  selected?: boolean;
 }
 
-const BtnToChip = ({ label = "BtnToChip", onClick, rightIcon }: BtnToChipProps) => {
+const BtnToChip = ({ label = "BtnToChip", onClick, rightIcon, selected = false }: BtnToChipProps) => {
   return (
-    <button onClick={onClick} className={styles.wrapper({ selected: false })}>
+    <button onClick={onClick} className={styles.wrapper({ selected })}>
       <span className={styles.buttonText}>
         {label} {rightIcon && <div className={styles.icon}>{rightIcon}</div>}
       </span>

--- a/src/app/review/write/_component/BtnToChip.tsx
+++ b/src/app/review/write/_component/BtnToChip.tsx
@@ -5,13 +5,18 @@ interface BtnToChipProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   rightIcon?: React.ReactNode;
   selected?: boolean;
+  onRightIconClick?: React.MouseEventHandler<HTMLDivElement>;
 }
-
-const BtnToChip = ({ label = "BtnToChip", onClick, rightIcon, selected = false }: BtnToChipProps) => {
+const BtnToChip = ({ label = "BtnToChip", onClick, rightIcon, onRightIconClick, selected = false }: BtnToChipProps) => {
   return (
     <button onClick={onClick} className={styles.wrapper({ selected })}>
       <span className={styles.buttonText}>
-        {label} {rightIcon && <div className={styles.icon}>{rightIcon}</div>}
+        {label}
+        {rightIcon && (
+          <div className={styles.icon} onClick={onRightIconClick}>
+            {rightIcon}
+          </div>
+        )}
       </span>
     </button>
   );

--- a/src/app/review/write/_component/CategoryContent.tsx
+++ b/src/app/review/write/_component/CategoryContent.tsx
@@ -1,0 +1,66 @@
+import { styles } from "@shared/component/FilterBottomSheet/CategoryContent/CategoryContent.css";
+import DropDownText from "@common/component/DropDownText/DropDownText";
+
+interface CategoryContentProps {
+  category: "symptom" | "disease";
+}
+const dummyData = {
+  symptom: [
+    {
+      id: 1,
+      name: "기침",
+      symptoms: [
+        { id: 101, name: "마른 기침" },
+        { id: 102, name: "가래 기침" },
+      ],
+    },
+    {
+      id: 2,
+      name: "구토",
+      symptoms: [
+        { id: 201, name: "구역감" },
+        { id: 202, name: "위통" },
+      ],
+    },
+  ],
+  disease: [
+    {
+      id: 1,
+      name: "감기",
+      diseases: [
+        { id: 301, name: "코감기" },
+        { id: 302, name: "독감" },
+      ],
+    },
+  ],
+};
+
+const CategoryContent = ({ category }: CategoryContentProps) => {
+  if (category === "symptom") {
+    return (
+      <div className={styles.symptomsWrapper}>
+        {dummyData.symptom.map((symptom) => (
+          <DropDownText key={symptom.id} content={symptom.symptoms} parentKey="symptomIds">
+            {symptom.name}
+          </DropDownText>
+        ))}
+      </div>
+    );
+  }
+
+  if (category === "disease") {
+    return (
+      <div className={styles.symptomsWrapper}>
+        {dummyData.disease.map((disease) => (
+          <DropDownText key={disease.id} content={disease.diseases} parentKey="diseaseIds">
+            {disease.name}
+          </DropDownText>
+        ))}
+      </div>
+    );
+  }
+
+  return <div>Nothing</div>;
+};
+
+export default CategoryContent;

--- a/src/app/review/write/_component/CategoryContent.tsx
+++ b/src/app/review/write/_component/CategoryContent.tsx
@@ -1,10 +1,10 @@
 import { styles } from "@shared/component/FilterBottomSheet/CategoryContent/CategoryContent.css";
-import DropDownText from "@common/component/DropDownText/DropDownText";
+import DropDownText from "@app/review/write/_component/DropDownText";
+import { useFormContext } from "react-hook-form";
+import type { ReviewFormData } from "@app/review/write/page";
 
-interface CategoryContentProps {
-  category: "symptom" | "disease";
-}
-const dummyData = {
+// ⚠️ 삭제 예정 목데이터
+export const dummyData = {
   symptom: [
     {
       id: 1,
@@ -34,13 +34,27 @@ const dummyData = {
     },
   ],
 };
+interface CategoryContentProps {
+  category: "symptom" | "disease";
+  onSymptomChipSelect: (chipId: number) => void;
+  onDiseaseChipSelect: (chipId: number) => void;
+}
 
-const CategoryContent = ({ category }: CategoryContentProps) => {
+const CategoryContent = ({ category, onSymptomChipSelect, onDiseaseChipSelect }: CategoryContentProps) => {
+  const { watch } = useFormContext<ReviewFormData>();
+  const selectedSymptomIds = watch("symptomIds") ?? [];
+  const selectedDiseaseId = watch("diseaseId") ?? -1;
+
   if (category === "symptom") {
     return (
       <div className={styles.symptomsWrapper}>
         {dummyData.symptom.map((symptom) => (
-          <DropDownText key={symptom.id} content={symptom.symptoms} parentKey="symptomIds">
+          <DropDownText
+            key={symptom.id}
+            content={symptom.symptoms}
+            selectedChipIds={selectedSymptomIds}
+            onChipToggle={(chip) => onSymptomChipSelect(chip.id)}
+          >
             {symptom.name}
           </DropDownText>
         ))}
@@ -52,7 +66,12 @@ const CategoryContent = ({ category }: CategoryContentProps) => {
     return (
       <div className={styles.symptomsWrapper}>
         {dummyData.disease.map((disease) => (
-          <DropDownText key={disease.id} content={disease.diseases} parentKey="diseaseIds">
+          <DropDownText
+            key={disease.id}
+            content={disease.diseases}
+            selectedChipIds={selectedDiseaseId === -1 ? [] : [selectedDiseaseId]}
+            onChipToggle={(chip) => onDiseaseChipSelect(chip.id)}
+          >
             {disease.name}
           </DropDownText>
         ))}

--- a/src/app/review/write/_component/CategoryContent.tsx
+++ b/src/app/review/write/_component/CategoryContent.tsx
@@ -6,37 +6,6 @@ import { bodiesGetResponse } from "@api/domain/register-pet/bodies";
 import { symptomGetResponse } from "@api/domain/register-pet/symptom";
 import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 
-// ⚠️ 삭제 예정 목데이터
-export const dummyData = {
-  symptom: [
-    {
-      id: 1,
-      name: "기침",
-      symptoms: [
-        { id: 101, name: "마른 기침" },
-        { id: 102, name: "가래 기침" },
-      ],
-    },
-    {
-      id: 2,
-      name: "구토",
-      symptoms: [
-        { id: 201, name: "구역감" },
-        { id: 202, name: "위통" },
-      ],
-    },
-  ],
-  disease: [
-    {
-      id: 1,
-      name: "감기",
-      diseases: [
-        { id: 301, name: "코감기" },
-        { id: 302, name: "독감" },
-      ],
-    },
-  ],
-};
 interface CategoryContentProps {
   category: "symptom" | "disease";
   onSymptomChipSelect: (chipId: number) => void;

--- a/src/app/review/write/_component/CategoryContent.tsx
+++ b/src/app/review/write/_component/CategoryContent.tsx
@@ -2,6 +2,9 @@ import { styles } from "@shared/component/FilterBottomSheet/CategoryContent/Cate
 import DropDownText from "@app/review/write/_component/DropDownText";
 import { useFormContext } from "react-hook-form";
 import type { ReviewFormData } from "@app/review/write/page";
+import { bodiesGetResponse } from "@api/domain/register-pet/bodies";
+import { symptomGetResponse } from "@api/domain/register-pet/symptom";
+import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 
 // ⚠️ 삭제 예정 목데이터
 export const dummyData = {
@@ -38,9 +41,20 @@ interface CategoryContentProps {
   category: "symptom" | "disease";
   onSymptomChipSelect: (chipId: number) => void;
   onDiseaseChipSelect: (chipId: number) => void;
+  symptomData?: bodiesGetResponse["data"];
+  diseaseData?: bodiesGetResponse["data"];
+  symptomBodyData?: symptomGetResponse["data"];
+  diseaseBodyData?: diseaseGetResponse["data"];
 }
-
-const CategoryContent = ({ category, onSymptomChipSelect, onDiseaseChipSelect }: CategoryContentProps) => {
+const CategoryContent = ({
+  category,
+  onSymptomChipSelect,
+  onDiseaseChipSelect,
+  symptomData,
+  diseaseData,
+  symptomBodyData,
+  diseaseBodyData,
+}: CategoryContentProps) => {
   const { watch } = useFormContext<ReviewFormData>();
   const selectedSymptomIds = watch("symptomIds") ?? [];
   const selectedDiseaseId = watch("diseaseId") ?? -1;
@@ -48,14 +62,19 @@ const CategoryContent = ({ category, onSymptomChipSelect, onDiseaseChipSelect }:
   if (category === "symptom") {
     return (
       <div className={styles.symptomsWrapper}>
-        {dummyData.symptom.map((symptom) => (
+        {symptomData?.bodies?.map((symptom) => (
           <DropDownText
             key={symptom.id}
-            content={symptom.symptoms}
+            content={
+              (symptomBodyData?.bodies?.find((body) => body.id === symptom.id)?.symptoms ?? []) as {
+                id: number;
+                name: string;
+              }[]
+            }
             selectedChipIds={selectedSymptomIds}
             onChipToggle={(chip) => onSymptomChipSelect(chip.id)}
           >
-            {symptom.name}
+            {symptom.name ?? ""}
           </DropDownText>
         ))}
       </div>
@@ -65,14 +84,19 @@ const CategoryContent = ({ category, onSymptomChipSelect, onDiseaseChipSelect }:
   if (category === "disease") {
     return (
       <div className={styles.symptomsWrapper}>
-        {dummyData.disease.map((disease) => (
+        {diseaseData?.bodies?.map((disease) => (
           <DropDownText
             key={disease.id}
-            content={disease.diseases}
+            content={
+              (diseaseBodyData?.bodies?.find((body) => body.id === disease.id)?.diseases ?? []) as {
+                id: number;
+                name: string;
+              }[]
+            }
             selectedChipIds={selectedDiseaseId === -1 ? [] : [selectedDiseaseId]}
             onChipToggle={(chip) => onDiseaseChipSelect(chip.id)}
           >
-            {disease.name}
+            {disease.name ?? ""}
           </DropDownText>
         ))}
       </div>
@@ -81,5 +105,4 @@ const CategoryContent = ({ category, onSymptomChipSelect, onDiseaseChipSelect }:
 
   return <div>Nothing</div>;
 };
-
 export default CategoryContent;

--- a/src/app/review/write/_component/DropDownText.tsx
+++ b/src/app/review/write/_component/DropDownText.tsx
@@ -1,0 +1,38 @@
+import { IcUp } from "@asset/svg";
+import * as styles from "@common/component/DropDownText/DropDownText.css";
+import { useState } from "react";
+import Chip from "@common/component/Chip/Chip";
+
+interface DropDownTextProps {
+  children: string;
+  content: { id: number; name: string }[];
+  selectedChipIds: number[];
+  onChipToggle: (chip: { id: number; name: string }) => void;
+}
+
+const DropDownText = ({ children, content, selectedChipIds, onChipToggle }: DropDownTextProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isSelected = (id: number) => selectedChipIds.includes(id);
+
+  return (
+    <div className={styles.dropdownTextWrapper}>
+      {/* 대분류 */}
+      <div className={styles.dropdownText} onClick={() => setIsOpen((prev) => !prev)}>
+        <span style={{ width: "100%" }}>{children}</span>
+        <IcUp className={styles.rotateIcon({ isOpen })} />
+      </div>
+
+      {/* 소분류 칩 */}
+      {isOpen && (
+        <div className={styles.dropdownContent}>
+          {content.map((data) => (
+            <Chip key={data.id} label={data.name} isSelected={isSelected(data.id)} onClick={() => onChipToggle(data)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DropDownText;

--- a/src/app/review/write/_component/DropDownText.tsx
+++ b/src/app/review/write/_component/DropDownText.tsx
@@ -26,7 +26,7 @@ const DropDownText = ({ children, content, selectedChipIds, onChipToggle }: Drop
       {/* 소분류 칩 */}
       {isOpen && (
         <div className={styles.dropdownContent}>
-          {content.map((data) => (
+          {content?.map((data) => (
             <Chip key={data.id} label={data.name} isSelected={isSelected(data.id)} onClick={() => onChipToggle(data)} />
           ))}
         </div>

--- a/src/app/review/write/_component/ReviewDisease.style.css.ts
+++ b/src/app/review/write/_component/ReviewDisease.style.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+import { color, font } from "@style/styles.css";
+
+export const wrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.8rem",
+});
+
+export const questionStyle = style([
+  font.body01,
+  {
+    color: color.gray.gray900,
+  },
+]);

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -1,16 +1,29 @@
+import { useFormContext } from "react-hook-form";
 import * as styles from "./ReviewDisease.style.css";
 import { IcRightArror } from "@asset/svg/index";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
+import { getNameById } from "@app/review/write/_component/SearchSymptomDisease"; // 이미 있는 util 함수 사용
+import { ReviewFormData } from "@app/review/write/page";
 
 interface ReviewDiseaseProps {
   onCategoryChange: (category: "symptom" | "disease") => void;
 }
 
 const ReviewDisease = ({ onCategoryChange }: ReviewDiseaseProps) => {
+  const { watch } = useFormContext<ReviewFormData>();
+  const selectedDiseaseId = watch("diseaseId");
+
+  const diseaseName = selectedDiseaseId !== -1 ? getNameById(selectedDiseaseId) : "진단 내용 추가하기";
+
   return (
     <div className={styles.wrapper}>
       <span className={styles.questionStyle}>진단받은 내용이 있나요?</span>
-      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} onClick={() => onCategoryChange("disease")} />
+      <BtnToChip
+        label={diseaseName}
+        rightIcon={<IcRightArror stroke={selectedDiseaseId !== -1 ? "#3DC4F5" : undefined} />}
+        onClick={() => onCategoryChange("disease")}
+        selected={selectedDiseaseId !== -1}
+      />
     </div>
   );
 };

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -2,11 +2,15 @@ import * as styles from "./ReviewDisease.style.css";
 import { IcRightArror } from "@asset/svg/index";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
 
-const ReviewDisease = () => {
+interface ReviewDiseaseProps {
+  handleOpenBottomSheet: () => void;
+}
+
+const ReviewDisease = ({ handleOpenBottomSheet }: ReviewDiseaseProps) => {
   return (
     <div className={styles.wrapper}>
       <span className={styles.questionStyle}>진단받은 내용이 있나요?</span>
-      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} />
+      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} onClick={handleOpenBottomSheet} />
     </div>
   );
 };

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -3,14 +3,14 @@ import { IcRightArror } from "@asset/svg/index";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
 
 interface ReviewDiseaseProps {
-  handleOpenBottomSheet: () => void;
+  onCategoryChange: (category: "symptom" | "disease") => void;
 }
 
-const ReviewDisease = ({ handleOpenBottomSheet }: ReviewDiseaseProps) => {
+const ReviewDisease = ({ onCategoryChange }: ReviewDiseaseProps) => {
   return (
     <div className={styles.wrapper}>
       <span className={styles.questionStyle}>진단받은 내용이 있나요?</span>
-      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} onClick={handleOpenBottomSheet} />
+      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} onClick={() => onCategoryChange("disease")} />
     </div>
   );
 };

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -1,0 +1,14 @@
+import * as styles from "./ReviewDisease.style.css";
+import { IcRightArror } from "@asset/svg/index";
+import BtnToChip from "@app/review/write/_component/BtnToChip";
+
+const ReviewDisease = () => {
+  return (
+    <div className={styles.wrapper}>
+      <span className={styles.questionStyle}>진단받은 내용이 있나요?</span>
+      <BtnToChip label="진단 내용 추가하기" rightIcon={<IcRightArror />} />
+    </div>
+  );
+};
+
+export default ReviewDisease;

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from "react-hook-form";
 import * as styles from "./ReviewDisease.style.css";
 import { IcRightArror } from "@asset/svg/index";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
-import { getNameById } from "@app/review/write/_component/SearchSymptomDisease"; // 이미 있는 util 함수 사용
+import { getNameById } from "@app/review/write/_utils/getNameById";
 import { ReviewFormData } from "@app/review/write/page";
 
 interface ReviewDiseaseProps {

--- a/src/app/review/write/_component/ReviewDisease.tsx
+++ b/src/app/review/write/_component/ReviewDisease.tsx
@@ -2,18 +2,21 @@ import { useFormContext } from "react-hook-form";
 import * as styles from "./ReviewDisease.style.css";
 import { IcRightArror } from "@asset/svg/index";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
-import { getNameById } from "@app/review/write/_utils/getNameById";
+import { getDiseaseNameById } from "@app/review/write/_utils/getNameById";
 import { ReviewFormData } from "@app/review/write/page";
+import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 
 interface ReviewDiseaseProps {
   onCategoryChange: (category: "symptom" | "disease") => void;
+  diseaseBodyData?: diseaseGetResponse["data"];
 }
 
-const ReviewDisease = ({ onCategoryChange }: ReviewDiseaseProps) => {
+const ReviewDisease = ({ onCategoryChange, diseaseBodyData }: ReviewDiseaseProps) => {
   const { watch } = useFormContext<ReviewFormData>();
   const selectedDiseaseId = watch("diseaseId");
 
-  const diseaseName = selectedDiseaseId !== -1 ? getNameById(selectedDiseaseId) : "진단 내용 추가하기";
+  const diseaseName =
+    selectedDiseaseId !== -1 ? getDiseaseNameById(selectedDiseaseId, diseaseBodyData) : "진단 내용 추가하기";
 
   return (
     <div className={styles.wrapper}>

--- a/src/app/review/write/_component/ReviewPurpose.style.css.ts
+++ b/src/app/review/write/_component/ReviewPurpose.style.css.ts
@@ -1,0 +1,27 @@
+import { style } from "@vanilla-extract/css";
+import { color, font } from "@style/styles.css";
+
+export const wrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.2rem",
+});
+
+export const questionStyle = style([
+  font.body01,
+  {
+    color: color.gray.gray900,
+  },
+]);
+
+export const starStyle = style([
+  font.body01,
+  {
+    color: color.red.warning_red200,
+  },
+]);
+export const chipLayout = style({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "1.2rem 0.4rem",
+});

--- a/src/app/review/write/_component/ReviewPurpose.tsx
+++ b/src/app/review/write/_component/ReviewPurpose.tsx
@@ -1,9 +1,17 @@
 import Chip from "@common/component/Chip/Chip";
 import * as styles from "./ReviewPurpose.style.css";
 import { usePurposeGet } from "@app/api/review/write/hook";
+import { useFormContext } from "react-hook-form";
+import { ReviewFormData } from "@app/review/write/page";
 
 const ReviewPurpose = () => {
   const { data } = usePurposeGet();
+  const { watch, setValue } = useFormContext<ReviewFormData>();
+  const selectedPurposeId = watch("purposeId");
+
+  const handleSelect = (id: number) => {
+    setValue("purposeId", selectedPurposeId === id ? -1 : id);
+  };
 
   return (
     <div>
@@ -14,7 +22,16 @@ const ReviewPurpose = () => {
         </div>
         <div className={styles.chipLayout}>
           {data?.purposes?.map((purpose) => (
-            <Chip key={purpose.id} label={purpose.label ?? ""} />
+            <Chip
+              key={purpose.id}
+              label={purpose.label ?? ""}
+              isSelected={selectedPurposeId === purpose.id}
+              onClick={() => {
+                if (purpose.id !== undefined) {
+                  handleSelect(purpose.id);
+                }
+              }}
+            />
           ))}
         </div>
       </section>

--- a/src/app/review/write/_component/ReviewPurpose.tsx
+++ b/src/app/review/write/_component/ReviewPurpose.tsx
@@ -1,0 +1,23 @@
+import Chip from "@common/component/Chip/Chip";
+import * as styles from "./ReviewPurpose.style.css";
+import { PURPOSE_LABELS } from "@app/review/write/constant";
+
+const ReviewPurpose = () => {
+  return (
+    <div>
+      <section className={styles.wrapper}>
+        <div>
+          <span className={styles.questionStyle}>어떤 목적으로 방문했나요?</span>
+          <span className={styles.starStyle}>*</span>
+        </div>
+        <div className={styles.chipLayout}>
+          {PURPOSE_LABELS.map((label) => (
+            <Chip key={label} label={label} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ReviewPurpose;

--- a/src/app/review/write/_component/ReviewPurpose.tsx
+++ b/src/app/review/write/_component/ReviewPurpose.tsx
@@ -1,8 +1,10 @@
 import Chip from "@common/component/Chip/Chip";
 import * as styles from "./ReviewPurpose.style.css";
-import { PURPOSE_LABELS } from "@app/review/write/constant";
+import { usePurposeGet } from "@app/api/review/write/hook";
 
 const ReviewPurpose = () => {
+  const { data } = usePurposeGet();
+
   return (
     <div>
       <section className={styles.wrapper}>
@@ -11,8 +13,8 @@ const ReviewPurpose = () => {
           <span className={styles.starStyle}>*</span>
         </div>
         <div className={styles.chipLayout}>
-          {PURPOSE_LABELS.map((label) => (
-            <Chip key={label} label={label} />
+          {data?.purposes?.map((purpose) => (
+            <Chip key={purpose.id} label={purpose.label ?? ""} />
           ))}
         </div>
       </section>

--- a/src/app/review/write/_component/ReviewSymptom.style.css.ts
+++ b/src/app/review/write/_component/ReviewSymptom.style.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+import { color, font } from "@style/styles.css";
+
+export const wrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.8rem",
+});
+
+export const questionStyle = style([
+  font.body01,
+  {
+    color: color.gray.gray900,
+  },
+]);

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -1,15 +1,33 @@
-import { IcRightArror } from "@asset/svg/index";
+import { useFormContext } from "react-hook-form";
+import { IcRightArror, IcReviewRightIcon } from "@asset/svg/index";
 import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
-
+import { getNameById } from "@app/review/write/_component/SearchSymptomDisease"; // 이미 있는 util 함수 사용
+import { ReviewFormData } from "@app/review/write/page";
 interface ReviewSymptomProps {
   onCategoryChange: (category: "symptom" | "disease") => void;
 }
-
 const ReviewSymptom = ({ onCategoryChange }: ReviewSymptomProps) => {
+  const { watch, setValue } = useFormContext<ReviewFormData>();
+  const selectedSymptomIds = watch("symptomIds");
+
+  const handleRemoveSymptom = (removeId: number) => {
+    const updated = selectedSymptomIds.filter((id) => id !== removeId);
+    setValue("symptomIds", updated);
+  };
+
   return (
     <div className={styles.wrapper}>
       <span className={styles.questionStyle}>어떤 증상으로 방문했나요?</span>
+      {selectedSymptomIds.map((id) => (
+        <BtnToChip
+          key={id}
+          label={getNameById(id)}
+          selected={true}
+          rightIcon={<IcReviewRightIcon />}
+          onRightIconClick={() => handleRemoveSymptom(id)}
+        />
+      ))}
       <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} onClick={() => onCategoryChange("symptom")} />
     </div>
   );

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -3,14 +3,14 @@ import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
 
 interface ReviewSymptomProps {
-  handleOpenSearchSymptom: () => void;
+  handleOpenBottomSheet: () => void;
 }
 
-const ReviewSymptom = ({ handleOpenSearchSymptom }: ReviewSymptomProps) => {
+const ReviewSymptom = ({ handleOpenBottomSheet }: ReviewSymptomProps) => {
   return (
-    <div className={styles.wrapper} onClick={handleOpenSearchSymptom}>
+    <div className={styles.wrapper}>
       <span className={styles.questionStyle}>어떤 증상으로 방문했나요?</span>
-      <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} />
+      <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} onClick={handleOpenBottomSheet} />
     </div>
   );
 };

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -1,0 +1,14 @@
+import { IcRightArror } from "@asset/svg/index";
+import * as styles from "./ReviewSymptom.style.css";
+import BtnToChip from "@app/review/write/_component/BtnToChip";
+
+const ReviewSymptom = () => {
+  return (
+    <div className={styles.wrapper}>
+      <span className={styles.questionStyle}>어떤 증상으로 방문했나요?</span>
+      <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} />
+    </div>
+  );
+};
+
+export default ReviewSymptom;

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from "react-hook-form";
 import { IcRightArror, IcReviewRightIcon } from "@asset/svg/index";
 import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
-import { getNameById } from "@app/review/write/_component/SearchSymptomDisease"; // 이미 있는 util 함수 사용
+import { getNameById } from "@app/review/write/_utils/getNameById";
 import { ReviewFormData } from "@app/review/write/page";
 interface ReviewSymptomProps {
   onCategoryChange: (category: "symptom" | "disease") => void;

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -2,9 +2,13 @@ import { IcRightArror } from "@asset/svg/index";
 import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
 
-const ReviewSymptom = () => {
+interface ReviewSymptomProps {
+  handleOpenSearchSymptom: () => void;
+}
+
+const ReviewSymptom = ({ handleOpenSearchSymptom }: ReviewSymptomProps) => {
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} onClick={handleOpenSearchSymptom}>
       <span className={styles.questionStyle}>어떤 증상으로 방문했나요?</span>
       <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} />
     </div>

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -3,14 +3,14 @@ import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
 
 interface ReviewSymptomProps {
-  handleOpenBottomSheet: () => void;
+  onCategoryChange: (category: "symptom" | "disease") => void;
 }
 
-const ReviewSymptom = ({ handleOpenBottomSheet }: ReviewSymptomProps) => {
+const ReviewSymptom = ({ onCategoryChange }: ReviewSymptomProps) => {
   return (
     <div className={styles.wrapper}>
       <span className={styles.questionStyle}>어떤 증상으로 방문했나요?</span>
-      <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} onClick={handleOpenBottomSheet} />
+      <BtnToChip label="증상 없음" rightIcon={<IcRightArror />} onClick={() => onCategoryChange("symptom")} />
     </div>
   );
 };

--- a/src/app/review/write/_component/ReviewSymptom.tsx
+++ b/src/app/review/write/_component/ReviewSymptom.tsx
@@ -2,12 +2,18 @@ import { useFormContext } from "react-hook-form";
 import { IcRightArror, IcReviewRightIcon } from "@asset/svg/index";
 import * as styles from "./ReviewSymptom.style.css";
 import BtnToChip from "@app/review/write/_component/BtnToChip";
-import { getNameById } from "@app/review/write/_utils/getNameById";
+import { getSymptomNameById } from "@app/review/write/_utils/getNameById";
 import { ReviewFormData } from "@app/review/write/page";
+import { symptomGetResponse } from "@api/domain/register-pet/symptom";
+import { diseaseGetResponse } from "@api/domain/register-pet/disease";
+
 interface ReviewSymptomProps {
   onCategoryChange: (category: "symptom" | "disease") => void;
+  symptomBodyData?: symptomGetResponse["data"];
+  diseaseBodyData?: diseaseGetResponse["data"];
 }
-const ReviewSymptom = ({ onCategoryChange }: ReviewSymptomProps) => {
+
+const ReviewSymptom = ({ onCategoryChange, symptomBodyData }: ReviewSymptomProps) => {
   const { watch, setValue } = useFormContext<ReviewFormData>();
   const selectedSymptomIds = watch("symptomIds");
 
@@ -22,8 +28,8 @@ const ReviewSymptom = ({ onCategoryChange }: ReviewSymptomProps) => {
       {selectedSymptomIds.map((id) => (
         <BtnToChip
           key={id}
-          label={getNameById(id)}
-          selected={true}
+          label={getSymptomNameById(id, symptomBodyData)}
+          selected
           rightIcon={<IcReviewRightIcon />}
           onRightIconClick={() => handleRemoveSymptom(id)}
         />

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -12,6 +12,7 @@ import { getSymptomNameById, getDiseaseNameById } from "@app/review/write/_utils
 import { symptomGetResponse } from "@api/domain/register-pet/symptom";
 import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 import { bodiesGetResponse } from "@api/domain/register-pet/bodies";
+
 type CategoryType = "symptom" | "disease";
 
 interface SearchSymptomDiseaseProps {

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -3,6 +3,7 @@ import * as styles from "@shared/component/FilterBottomSheet/FilterBottomSheet.c
 import Tab from "@common/component/Tab/Tab";
 import { Button } from "@common/component/Button";
 import { useState } from "react";
+import CategoryContent from "@app/review/write/_component/CategoryContent";
 
 type CategoryType = "symptom" | "disease";
 
@@ -34,8 +35,7 @@ const SearchSymptomDisease = ({ isOpen, onClose, onSubmit }: SearchSymptomDiseas
 
         {/* 탭별 컨텐츠 */}
         <div className={styles.bodyZone}>
-          {selectedCategory === "symptom" && <p>첫번째 카테고리 내용</p>}
-          {selectedCategory === "disease" && <p>두번째 카테고리 내용</p>}
+          <CategoryContent category={selectedCategory} />
         </div>
 
         {/* 확인 버튼 */}

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -10,6 +10,10 @@ import CategoryContent from "@app/review/write/_component/CategoryContent";
 import { ReviewFormData } from "@app/review/write/page";
 import { dummyData } from "@app/review/write/_component/CategoryContent";
 
+import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
+import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
+import { useSymptomGet } from "@api/domain/register-pet/symptom/hook";
+
 type CategoryType = "symptom" | "disease";
 
 interface SearchSymptomDiseaseProps {
@@ -45,6 +49,20 @@ const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryCha
     setValue("diseaseId", selectedDiseaseId === chipId ? -1 : chipId);
   };
 
+  // api - 신체 조회
+  const { data: diseaseData } = useBodiesGet("disease");
+  const { data: symptomData } = useBodiesGet("symptom");
+
+  // 모든 bodyId 추출
+  const allDiseaseBodyIds =
+    diseaseData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
+  const allSymptomBodyIds =
+    symptomData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
+
+  // api - 세부 이름 조회
+  const { data: symptomBodyData } = useSymptomGet(allSymptomBodyIds);
+  const { data: diseaseBodyData } = useDiseaseGet(allDiseaseBodyIds);
+
   return (
     <BottomSheet isOpen={isOpen} handleOpen={() => {}} handleDimmedClose={onClose}>
       <>
@@ -75,6 +93,10 @@ const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryCha
         {/* 탭 내용 */}
         <div className={styles.bodyZone}>
           <CategoryContent
+            diseaseData={diseaseData?.data}
+            diseaseBodyData={diseaseBodyData}
+            symptomData={symptomData?.data}
+            symptomBodyData={symptomBodyData}
             category={selectedCategory}
             onSymptomChipSelect={toggleSymptomChip}
             onDiseaseChipSelect={toggleDiseaseChip}

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -1,5 +1,4 @@
 import * as styles from "@shared/component/FilterBottomSheet/FilterBottomSheet.css";
-import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 import BottomSheet from "@common/component/BottomSheet/BottomSheet";
@@ -16,6 +15,8 @@ type CategoryType = "symptom" | "disease";
 interface SearchSymptomDiseaseProps {
   isOpen: boolean;
   onClose: () => void;
+  selectedCategory: CategoryType;
+  onCategoryChange: (category: CategoryType) => void;
 }
 
 const CATEGORIES: { id: CategoryType; label: string }[] = [
@@ -24,14 +25,10 @@ const CATEGORIES: { id: CategoryType; label: string }[] = [
 ];
 
 const getNameById = (id: number): string => {
-  const allItems = [
-    ...dummyData.symptom.flatMap((s) => s.symptoms),
-    ...dummyData.disease.flatMap((d) => d.diseases),
-  ];
+  const allItems = [...dummyData.symptom.flatMap((s) => s.symptoms), ...dummyData.disease.flatMap((d) => d.diseases)];
   return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
 };
-const SearchSymptomDisease = ({ isOpen, onClose }: SearchSymptomDiseaseProps) => {
-  const [selectedCategory, setSelectedCategory] = useState<CategoryType>("symptom");
+const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryChange }: SearchSymptomDiseaseProps) => {
   const { watch, setValue } = useFormContext<ReviewFormData>();
 
   const selectedSymptomIds = watch("symptomIds") ?? [];
@@ -54,12 +51,7 @@ const SearchSymptomDisease = ({ isOpen, onClose }: SearchSymptomDiseaseProps) =>
         {/* 선택된 칩 */}
         <div className={styles.selectedZone}>
           {selectedSymptomIds.map((chipId) => (
-            <Chip
-              icon
-              key={chipId}
-              label={getNameById(chipId)}
-              onClick={() => toggleSymptomChip(chipId)}
-            />
+            <Chip icon key={chipId} label={getNameById(chipId)} onClick={() => toggleSymptomChip(chipId)} />
           ))}
           {selectedDiseaseId !== -1 && (
             <Chip
@@ -74,7 +66,7 @@ const SearchSymptomDisease = ({ isOpen, onClose }: SearchSymptomDiseaseProps) =>
         {/* 탭 */}
         <div className={styles.categoryZone}>
           {CATEGORIES.map(({ id, label }) => (
-            <Tab key={id} active={selectedCategory === id} onClick={() => setSelectedCategory(id)}>
+            <Tab key={id} active={selectedCategory === id} onClick={() => onCategoryChange(id)}>
               {label}
             </Tab>
           ))}

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -9,12 +9,9 @@ import CategoryContent from "@app/review/write/_component/CategoryContent";
 import { ReviewFormData } from "@app/review/write/page";
 import { getSymptomNameById, getDiseaseNameById } from "@app/review/write/_utils/getNameById";
 
-import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
-import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
-import { useSymptomGet } from "@api/domain/register-pet/symptom/hook";
 import { symptomGetResponse } from "@api/domain/register-pet/symptom";
 import { diseaseGetResponse } from "@api/domain/register-pet/disease";
-
+import { bodiesGetResponse } from "@api/domain/register-pet/bodies";
 type CategoryType = "symptom" | "disease";
 
 interface SearchSymptomDiseaseProps {
@@ -22,8 +19,11 @@ interface SearchSymptomDiseaseProps {
   onClose: () => void;
   selectedCategory: CategoryType;
   onCategoryChange: (category: CategoryType) => void;
+
   symptomBodyData?: symptomGetResponse["data"];
   diseaseBodyData?: diseaseGetResponse["data"];
+  symptomData?: bodiesGetResponse["data"];
+  diseaseData?: bodiesGetResponse["data"];
 }
 
 const CATEGORIES: { id: CategoryType; label: string }[] = [
@@ -31,7 +31,16 @@ const CATEGORIES: { id: CategoryType; label: string }[] = [
   { id: "disease", label: "진단" },
 ];
 
-const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryChange }: SearchSymptomDiseaseProps) => {
+const SearchSymptomDisease = ({
+  isOpen,
+  onClose,
+  selectedCategory,
+  onCategoryChange,
+  symptomBodyData,
+  diseaseBodyData,
+  symptomData,
+  diseaseData,
+}: SearchSymptomDiseaseProps) => {
   const { watch, setValue } = useFormContext<ReviewFormData>();
 
   const selectedSymptomIds = watch("symptomIds") ?? [];
@@ -47,20 +56,6 @@ const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryCha
   const toggleDiseaseChip = (chipId: number) => {
     setValue("diseaseId", selectedDiseaseId === chipId ? -1 : chipId);
   };
-
-  // api - 신체 조회
-  const { data: diseaseData } = useBodiesGet("disease");
-  const { data: symptomData } = useBodiesGet("symptom");
-
-  // 모든 bodyId 추출
-  const allDiseaseBodyIds =
-    diseaseData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
-  const allSymptomBodyIds =
-    symptomData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
-
-  // api - 세부 이름 조회
-  const { data: symptomBodyData } = useSymptomGet(allSymptomBodyIds);
-  const { data: diseaseBodyData } = useDiseaseGet(allDiseaseBodyIds);
 
   return (
     <BottomSheet isOpen={isOpen} handleOpen={() => {}} handleDimmedClose={onClose}>
@@ -97,9 +92,9 @@ const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryCha
         {/* 탭 내용 */}
         <div className={styles.bodyZone}>
           <CategoryContent
-            diseaseData={diseaseData?.data}
+            diseaseData={diseaseData}
             diseaseBodyData={diseaseBodyData}
-            symptomData={symptomData?.data}
+            symptomData={symptomData}
             symptomBodyData={symptomBodyData}
             category={selectedCategory}
             onSymptomChipSelect={toggleSymptomChip}

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -24,7 +24,7 @@ const CATEGORIES: { id: CategoryType; label: string }[] = [
   { id: "disease", label: "진단" },
 ];
 
-const getNameById = (id: number): string => {
+export const getNameById = (id: number): string => {
   const allItems = [...dummyData.symptom.flatMap((s) => s.symptoms), ...dummyData.disease.flatMap((d) => d.diseases)];
   return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
 };

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -1,0 +1,58 @@
+import BottomSheet from "@common/component/BottomSheet/BottomSheet";
+import * as styles from "@shared/component/FilterBottomSheet/FilterBottomSheet.css";
+import Tab from "@common/component/Tab/Tab";
+import { Button } from "@common/component/Button";
+import { useState } from "react";
+
+type CategoryType = "symptom" | "disease";
+
+interface SearchSymptomDiseaseProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+const categories: { id: CategoryType; label: string }[] = [
+  { id: "symptom", label: "증상 선택하기" },
+  { id: "disease", label: "진단 선택하기" },
+];
+
+const SearchSymptomDisease = ({ isOpen, onClose, onSubmit }: SearchSymptomDiseaseProps) => {
+  const [selectedCategory, setSelectedCategory] = useState<CategoryType>("symptom");
+
+  return (
+    <BottomSheet isOpen={isOpen} handleOpen={() => {}} handleDimmedClose={onClose}>
+      <>
+        {/* 카테고리 탭 */}
+        <div className={styles.categoryZone}>
+          {categories.map(({ id, label }) => (
+            <Tab key={id} active={selectedCategory === id} onClick={() => setSelectedCategory(id)}>
+              {label}
+            </Tab>
+          ))}
+        </div>
+
+        {/* 탭별 컨텐츠 */}
+        <div className={styles.bodyZone}>
+          {selectedCategory === "symptom" && <p>첫번째 카테고리 내용</p>}
+          {selectedCategory === "disease" && <p>두번째 카테고리 내용</p>}
+        </div>
+
+        {/* 확인 버튼 */}
+        <div className={styles.buttonWrapper}>
+          <Button
+            label="확인하기"
+            size="large"
+            width="100%"
+            onClick={() => {
+              onClose();
+              onSubmit();
+            }}
+          />
+        </div>
+      </>
+    </BottomSheet>
+  );
+};
+
+export default SearchSymptomDisease;

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -7,11 +7,13 @@ import { Button } from "@common/component/Button";
 import Chip from "@common/component/Chip/Chip";
 import CategoryContent from "@app/review/write/_component/CategoryContent";
 import { ReviewFormData } from "@app/review/write/page";
-import { getNameById } from "@app/review/write/_utils/getNameById";
+import { getSymptomNameById, getDiseaseNameById } from "@app/review/write/_utils/getNameById";
 
 import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
 import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
 import { useSymptomGet } from "@api/domain/register-pet/symptom/hook";
+import { symptomGetResponse } from "@api/domain/register-pet/symptom";
+import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 
 type CategoryType = "symptom" | "disease";
 
@@ -20,6 +22,8 @@ interface SearchSymptomDiseaseProps {
   onClose: () => void;
   selectedCategory: CategoryType;
   onCategoryChange: (category: CategoryType) => void;
+  symptomBodyData?: symptomGetResponse["data"];
+  diseaseBodyData?: diseaseGetResponse["data"];
 }
 
 const CATEGORIES: { id: CategoryType; label: string }[] = [
@@ -64,13 +68,18 @@ const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryCha
         {/* 선택된 칩 */}
         <div className={styles.selectedZone}>
           {selectedSymptomIds.map((chipId) => (
-            <Chip icon key={chipId} label={getNameById(chipId)} onClick={() => toggleSymptomChip(chipId)} />
+            <Chip
+              icon
+              key={chipId}
+              label={getSymptomNameById(chipId, symptomBodyData)}
+              onClick={() => toggleSymptomChip(chipId)}
+            />
           ))}
           {selectedDiseaseId !== -1 && (
             <Chip
               icon
               key={selectedDiseaseId}
-              label={getNameById(selectedDiseaseId)}
+              label={getDiseaseNameById(selectedDiseaseId, diseaseBodyData)}
               onClick={() => toggleDiseaseChip(selectedDiseaseId)}
             />
           )}

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -1,58 +1,100 @@
-import BottomSheet from "@common/component/BottomSheet/BottomSheet";
 import * as styles from "@shared/component/FilterBottomSheet/FilterBottomSheet.css";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+import BottomSheet from "@common/component/BottomSheet/BottomSheet";
 import Tab from "@common/component/Tab/Tab";
 import { Button } from "@common/component/Button";
-import { useState } from "react";
+import Chip from "@common/component/Chip/Chip";
+
 import CategoryContent from "@app/review/write/_component/CategoryContent";
+import { ReviewFormData } from "@app/review/write/page";
+import { dummyData } from "@app/review/write/_component/CategoryContent";
 
 type CategoryType = "symptom" | "disease";
 
 interface SearchSymptomDiseaseProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: () => void;
 }
 
-const categories: { id: CategoryType; label: string }[] = [
-  { id: "symptom", label: "증상 선택하기" },
-  { id: "disease", label: "진단 선택하기" },
+const CATEGORIES: { id: CategoryType; label: string }[] = [
+  { id: "symptom", label: "증상" },
+  { id: "disease", label: "진단" },
 ];
 
-const SearchSymptomDisease = ({ isOpen, onClose, onSubmit }: SearchSymptomDiseaseProps) => {
+const getNameById = (id: number): string => {
+  const allItems = [
+    ...dummyData.symptom.flatMap((s) => s.symptoms),
+    ...dummyData.disease.flatMap((d) => d.diseases),
+  ];
+  return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
+};
+const SearchSymptomDisease = ({ isOpen, onClose }: SearchSymptomDiseaseProps) => {
   const [selectedCategory, setSelectedCategory] = useState<CategoryType>("symptom");
+  const { watch, setValue } = useFormContext<ReviewFormData>();
+
+  const selectedSymptomIds = watch("symptomIds") ?? [];
+  const selectedDiseaseId = watch("diseaseId");
+
+  const toggleSymptomChip = (chipId: number) => {
+    const updated = selectedSymptomIds.includes(chipId)
+      ? selectedSymptomIds.filter((id) => id !== chipId)
+      : [...selectedSymptomIds, chipId];
+    setValue("symptomIds", updated);
+  };
+
+  const toggleDiseaseChip = (chipId: number) => {
+    setValue("diseaseId", selectedDiseaseId === chipId ? -1 : chipId);
+  };
 
   return (
     <BottomSheet isOpen={isOpen} handleOpen={() => {}} handleDimmedClose={onClose}>
       <>
-        {/* 카테고리 탭 */}
+        {/* 선택된 칩 */}
+        <div className={styles.selectedZone}>
+          {selectedSymptomIds.map((chipId) => (
+            <Chip
+              icon
+              key={chipId}
+              label={getNameById(chipId)}
+              onClick={() => toggleSymptomChip(chipId)}
+            />
+          ))}
+          {selectedDiseaseId !== -1 && (
+            <Chip
+              icon
+              key={selectedDiseaseId}
+              label={getNameById(selectedDiseaseId)}
+              onClick={() => toggleDiseaseChip(selectedDiseaseId)}
+            />
+          )}
+        </div>
+
+        {/* 탭 */}
         <div className={styles.categoryZone}>
-          {categories.map(({ id, label }) => (
+          {CATEGORIES.map(({ id, label }) => (
             <Tab key={id} active={selectedCategory === id} onClick={() => setSelectedCategory(id)}>
               {label}
             </Tab>
           ))}
         </div>
 
-        {/* 탭별 컨텐츠 */}
+        {/* 탭 내용 */}
         <div className={styles.bodyZone}>
-          <CategoryContent category={selectedCategory} />
+          <CategoryContent
+            category={selectedCategory}
+            onSymptomChipSelect={toggleSymptomChip}
+            onDiseaseChipSelect={toggleDiseaseChip}
+          />
         </div>
 
-        {/* 확인 버튼 */}
+        {/* 하단 버튼 */}
         <div className={styles.buttonWrapper}>
-          <Button
-            label="확인하기"
-            size="large"
-            width="100%"
-            onClick={() => {
-              onClose();
-              onSubmit();
-            }}
-          />
+          <Button label="확인하기" size="large" width="100%" onClick={onClose} />
         </div>
       </>
     </BottomSheet>
   );
 };
-
 export default SearchSymptomDisease;

--- a/src/app/review/write/_component/SearchSymptomDisease.tsx
+++ b/src/app/review/write/_component/SearchSymptomDisease.tsx
@@ -5,10 +5,9 @@ import BottomSheet from "@common/component/BottomSheet/BottomSheet";
 import Tab from "@common/component/Tab/Tab";
 import { Button } from "@common/component/Button";
 import Chip from "@common/component/Chip/Chip";
-
 import CategoryContent from "@app/review/write/_component/CategoryContent";
 import { ReviewFormData } from "@app/review/write/page";
-import { dummyData } from "@app/review/write/_component/CategoryContent";
+import { getNameById } from "@app/review/write/_utils/getNameById";
 
 import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
 import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
@@ -28,10 +27,6 @@ const CATEGORIES: { id: CategoryType; label: string }[] = [
   { id: "disease", label: "진단" },
 ];
 
-export const getNameById = (id: number): string => {
-  const allItems = [...dummyData.symptom.flatMap((s) => s.symptoms), ...dummyData.disease.flatMap((d) => d.diseases)];
-  return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
-};
 const SearchSymptomDisease = ({ isOpen, onClose, selectedCategory, onCategoryChange }: SearchSymptomDiseaseProps) => {
   const { watch, setValue } = useFormContext<ReviewFormData>();
 

--- a/src/app/review/write/_section/Step1.style.css.ts
+++ b/src/app/review/write/_section/Step1.style.css.ts
@@ -1,0 +1,38 @@
+import { style } from "@vanilla-extract/css";
+import { color } from "@style/styles.css";
+
+export const preventScroll = style({
+  height: "100vh",
+  overflow: "hidden",
+});
+
+export const wrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "3.2rem",
+
+  width: "100%",
+  height: "calc(100vh - 15.2rem)",
+  padding: "2rem",
+  backgroundColor: color.gray.gray100,
+
+  overflow: "scroll",
+  scrollbarWidth: "none", // Firefox
+  msOverflowStyle: "none", // IE 10+
+  selectors: {
+    "&::-webkit-scrollbar": {
+      display: "none", // Chrome, Safari
+    },
+  },
+});
+
+export const buttonContainer = style({
+  position: "sticky",
+  bottom: "0rem",
+  left: "0",
+  width: "100%",
+  padding: "1.2rem 2rem 3.2rem 2rem",
+
+  backgroundColor: color.gray.gray000,
+  overflow: "scroll",
+});

--- a/src/app/review/write/_section/Step1.tsx
+++ b/src/app/review/write/_section/Step1.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { IcDeleteBlack } from "@asset/svg/index";
+import * as styles from "./Step1.style.css";
+
+import HeaderNav from "@common/component/HeaderNav/HeaderNav";
+import ReviewHospital from "@app/review/write/_component/ReviewHospital";
+import ReviewDate from "@app/review/write/_component/ReviewDate";
+import ReviewPetInfo from "@app/review/write/_component/ReviewPetInfo";
+import SearchHospital, { Hospital } from "@shared/component/SearchHospital/SearchHospital";
+import { Button } from "@common/component/Button/index";
+
+export type PetInfoType = "myPet" | "manual";
+
+const Page = () => {
+  // 병원 검색 바텀시트 열고 닫기
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  // 선택된 병원
+  const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
+  // 동물 정보 입력 방법 선택
+  const [selectedPetInfo, setSelectedPetInfo] = useState<PetInfoType | null>(null);
+
+  // 1-1. hospital ⚠️ 나갈 수 있는 방법이 2가지라 분리
+  const handleOpenSearchHospital = () => {
+    setIsBottomSheetOpen(true);
+  };
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetOpen(false);
+  };
+
+  const handleSelectHospital = (hospital: Hospital | null) => {
+    setSelectedHospital(hospital);
+  };
+
+  // 1-3. petInfo
+  const handleSelectPetInfo = (type: PetInfoType) => {
+    setSelectedPetInfo((prev) => (prev === type ? null : type));
+  };
+
+  return (
+    <div className={styles.preventScroll}>
+      {/* 상단 헤더 */}
+      <HeaderNav centerContent="리뷰작성(1/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
+
+      {/* 중앙 컨텐츠 */}
+      <div className={styles.wrapper}>
+        {/* 1-1. 병원 검색 */}
+        <ReviewHospital selectedHospital={selectedHospital} handleOpenSearchHospital={handleOpenSearchHospital} />
+        {/* 1-2. 날짜 선택 */}
+        <ReviewDate />
+        {/* 1-3. 동물 정보 */}
+        <ReviewPetInfo selectedPetInfo={selectedPetInfo} onSelectPetInfo={handleSelectPetInfo} />
+      </div>
+
+      {/* 하단 버튼 */}
+      <div className={styles.buttonContainer}>
+        <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} />
+      </div>
+
+      {/* 병원 검색 바텀시트 */}
+      <SearchHospital
+        active={isBottomSheetOpen}
+        onCloseBottomSheet={handleCloseBottomSheet}
+        selectedHospital={selectedHospital}
+        onSelectHospital={handleSelectHospital}
+      />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/review/write/_section/Step2.style.css.ts
+++ b/src/app/review/write/_section/Step2.style.css.ts
@@ -1,11 +1,29 @@
 import { style } from "@vanilla-extract/css";
+import { color } from "@style/styles.css";
+
+export const backgroundColor = style({
+  width: "100%",
+  height: "100dvh",
+  backgroundColor: color.gray.gray100,
+});
 
 export const wrapper = style({
   display: "flex",
   flexDirection: "column",
   gap: "3.2rem",
 
-  padding: "2rem 2rem 0",
+  height: "auto",
+  padding: "2rem 2rem 9rem",
+  overflow: "scroll",
+
+  scrollbarWidth: "none", // Firefox
+  msOverflowStyle: "none", // IE, Edge
+  // Webkit 계열 (Chrome, Safari)
+  selectors: {
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
 });
 
 export const btnLayout = style({
@@ -19,4 +37,5 @@ export const btnLayout = style({
   gap: "1.2rem",
   whiteSpace: "nowrap",
   padding: "1.2rem 2rem 3.2rem 2rem",
+  backgroundColor: color.gray.gray000,
 });

--- a/src/app/review/write/_section/Step2.style.css.ts
+++ b/src/app/review/write/_section/Step2.style.css.ts
@@ -1,0 +1,22 @@
+import { style } from "@vanilla-extract/css";
+
+export const wrapper = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "3.2rem",
+
+  padding: "2rem 2rem 0",
+});
+
+export const btnLayout = style({
+  maxWidth: "76.8rem",
+  width: "100%",
+  position: "fixed",
+  bottom: 0,
+
+  display: "grid",
+  gridTemplateColumns: "9.6rem calc(100% - 10.8rem)",
+  gap: "1.2rem",
+  whiteSpace: "nowrap",
+  padding: "1.2rem 2rem 3.2rem 2rem",
+});

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -9,10 +9,11 @@ import { useState } from "react";
 import SearchSymptomDisease from "@app/review/write/_component/SearchSymptomDisease";
 
 const Step2 = () => {
+  // 바텀시트 열고 닫기
   const [open, setOpen] = useState(false);
 
   // 증상& 바텀시트 열기
-  const handleOpenSearchSymptom = () => {
+  const handleOpenBottomSheet = () => {
     setOpen(true);
   };
 
@@ -30,13 +31,13 @@ const Step2 = () => {
       <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
       <div className={styles.wrapper}>
         {/* 2-1. 증상 */}
-        <ReviewSymptom handleOpenSearchSymptom={handleOpenSearchSymptom} />
+        <ReviewSymptom handleOpenBottomSheet={handleOpenBottomSheet} />
 
         {/* 2-2. 방문 목적 */}
         <ReviewPurpose />
 
         {/* 2-3. 진단 내용 */}
-        <ReviewDisease />
+        <ReviewDisease handleOpenBottomSheet={handleOpenBottomSheet} />
       </div>
 
       {/* 하단 버튼 */}
@@ -46,13 +47,7 @@ const Step2 = () => {
       </div>
 
       {/* 증상 진단 바텀시트 */}
-      <SearchSymptomDisease
-        isOpen={open}
-        onClose={() => setOpen(false)}
-        onSubmit={() => {
-          console.log("필터 적용됨!");
-        }}
-      />
+      <SearchSymptomDisease isOpen={open} onClose={() => setOpen(false)} />
     </>
   );
 };

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -8,52 +8,58 @@ import { Button } from "@common/component/Button";
 import { useState } from "react";
 import SearchSymptomDisease from "@app/review/write/_component/SearchSymptomDisease";
 
+import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
+import { useSymptomGet } from "@api/domain/register-pet/symptom/hook";
+import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
+
 type CategoryType = "symptom" | "disease";
 
 const Step2 = () => {
-  // 바텀시트 열고 닫기
   const [open, setOpen] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<CategoryType>("symptom");
 
-  // 증상& 바텀시트 열기
+  const { data: diseaseData } = useBodiesGet("disease");
+  const { data: symptomData } = useBodiesGet("symptom");
+
+  const allDiseaseBodyIds =
+    diseaseData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
+  const allSymptomBodyIds =
+    symptomData?.data?.bodies?.map((body) => body.id).filter((id): id is number => id !== undefined) ?? [];
+
+  const { data: symptomBodyData } = useSymptomGet(allSymptomBodyIds);
+  const { data: diseaseBodyData } = useDiseaseGet(allDiseaseBodyIds);
+
   const handleOpenBottomSheet = (category: CategoryType) => {
     setSelectedCategory(category);
     setOpen(true);
   };
 
-  const handleGoBack = () => {
-    console.log("뒤로가기 구현 예정");
-  };
-
-  const handleNext = () => {
-    console.log("다음 구현 예정, 활성화도!");
-  };
+  const handleGoBack = () => console.log("뒤로가기 구현 예정");
+  const handleNext = () => console.log("다음 구현 예정");
 
   return (
     <>
-      {/* 상단 헤더 */}
-      <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
+      <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack />} />
       <div className={styles.wrapper}>
-        {/* 2-1. 증상 */}
-        <ReviewSymptom onCategoryChange={handleOpenBottomSheet} />
-
-        {/* 2-2. 방문 목적 */}
+        <ReviewSymptom
+          onCategoryChange={handleOpenBottomSheet}
+          symptomBodyData={symptomBodyData}
+          diseaseBodyData={diseaseBodyData}
+        />
         <ReviewPurpose />
-
-        {/* 2-3. 진단 내용 */}
-        <ReviewDisease onCategoryChange={handleOpenBottomSheet} />
+        <ReviewDisease onCategoryChange={handleOpenBottomSheet} diseaseBodyData={diseaseBodyData} />
       </div>
-      {/* 하단 버튼 */}
       <div className={styles.btnLayout}>
-        <Button label="이전으로" size="large" variant="solidNeutral" disabled={false} onClick={handleGoBack} />
-        <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} onClick={handleNext} />
+        <Button label="이전으로" size="large" variant="solidNeutral" onClick={handleGoBack} />
+        <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} />
       </div>
-      {/* 증상 진단 바텀시트 */}
       <SearchSymptomDisease
         isOpen={open}
         onClose={() => setOpen(false)}
         selectedCategory={selectedCategory}
         onCategoryChange={setSelectedCategory}
+        symptomBodyData={symptomBodyData}
+        diseaseBodyData={diseaseBodyData}
       />
     </>
   );

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -8,12 +8,16 @@ import { Button } from "@common/component/Button";
 import { useState } from "react";
 import SearchSymptomDisease from "@app/review/write/_component/SearchSymptomDisease";
 
+type CategoryType = "symptom" | "disease";
+
 const Step2 = () => {
   // 바텀시트 열고 닫기
   const [open, setOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<CategoryType>("symptom");
 
   // 증상& 바텀시트 열기
-  const handleOpenBottomSheet = () => {
+  const handleOpenBottomSheet = (category: CategoryType) => {
+    setSelectedCategory(category);
     setOpen(true);
   };
 
@@ -31,23 +35,26 @@ const Step2 = () => {
       <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
       <div className={styles.wrapper}>
         {/* 2-1. 증상 */}
-        <ReviewSymptom handleOpenBottomSheet={handleOpenBottomSheet} />
+        <ReviewSymptom onCategoryChange={handleOpenBottomSheet} />
 
         {/* 2-2. 방문 목적 */}
         <ReviewPurpose />
 
         {/* 2-3. 진단 내용 */}
-        <ReviewDisease handleOpenBottomSheet={handleOpenBottomSheet} />
+        <ReviewDisease onCategoryChange={handleOpenBottomSheet} />
       </div>
-
       {/* 하단 버튼 */}
       <div className={styles.btnLayout}>
         <Button label="이전으로" size="large" variant="solidNeutral" disabled={false} onClick={handleGoBack} />
         <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} onClick={handleNext} />
       </div>
-
       {/* 증상 진단 바텀시트 */}
-      <SearchSymptomDisease isOpen={open} onClose={() => setOpen(false)} />
+      <SearchSymptomDisease
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        selectedCategory={selectedCategory}
+        onCategoryChange={setSelectedCategory}
+      />
     </>
   );
 };

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -5,23 +5,32 @@ import ReviewPurpose from "@app/review/write/_component/ReviewPurpose";
 import ReviewDisease from "@app/review/write/_component/ReviewDisease";
 import * as styles from "./Step2.style.css";
 import { Button } from "@common/component/Button";
-
-const handleGoBack = () => {
-  console.log("뒤로가기 구현 예정");
-};
-
-const handleNext = () => {
-  console.log("다음 구현 예정, 활성화도!");
-};
+import { useState } from "react";
+import SearchSymptomDisease from "@app/review/write/_component/SearchSymptomDisease";
 
 const Step2 = () => {
+  const [open, setOpen] = useState(false);
+
+  // 증상& 바텀시트 열기
+  const handleOpenSearchSymptom = () => {
+    setOpen(true);
+  };
+
+  const handleGoBack = () => {
+    console.log("뒤로가기 구현 예정");
+  };
+
+  const handleNext = () => {
+    console.log("다음 구현 예정, 활성화도!");
+  };
+
   return (
     <>
       {/* 상단 헤더 */}
       <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
       <div className={styles.wrapper}>
         {/* 2-1. 증상 */}
-        <ReviewSymptom />
+        <ReviewSymptom handleOpenSearchSymptom={handleOpenSearchSymptom} />
 
         {/* 2-2. 방문 목적 */}
         <ReviewPurpose />
@@ -29,11 +38,21 @@ const Step2 = () => {
         {/* 2-3. 진단 내용 */}
         <ReviewDisease />
       </div>
+
       {/* 하단 버튼 */}
       <div className={styles.btnLayout}>
         <Button label="이전으로" size="large" variant="solidNeutral" disabled={false} onClick={handleGoBack} />
         <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} onClick={handleNext} />
       </div>
+
+      {/* 증상 진단 바텀시트 */}
+      <SearchSymptomDisease
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSubmit={() => {
+          console.log("필터 적용됨!");
+        }}
+      />
     </>
   );
 };

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -39,30 +39,40 @@ const Step2 = () => {
 
   return (
     <div className={styles.backgroundColor}>
+      {/* 상단 헤더 영역 */}
       <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack />} />
+
       <section className={styles.wrapper}>
+        {/* 2-1. 증상 선택 */}
         <ReviewSymptom
           onCategoryChange={handleOpenBottomSheet}
           symptomBodyData={symptomBodyData}
           diseaseBodyData={diseaseBodyData}
         />
+        {/* 2-2. 방문 목적 */}
         <ReviewPurpose />
+
+        {/* 2-3. 질병 선택 */}
         <ReviewDisease onCategoryChange={handleOpenBottomSheet} diseaseBodyData={diseaseBodyData} />
       </section>
+
+      {/* 하단 버튼 영역 */}
       <section className={styles.btnLayout}>
         <Button label="이전으로" size="large" variant="solidNeutral" onClick={handleGoBack} />
         <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} />
       </section>
+
+      {/* 증상&질병 바텀시트 */}
       <SearchSymptomDisease
-  isOpen={open}
-  onClose={() => setOpen(false)}
-  selectedCategory={selectedCategory}
-  onCategoryChange={setSelectedCategory}
-  symptomData={symptomData?.data}
-  symptomBodyData={symptomBodyData}
-  diseaseData={diseaseData?.data}
-  diseaseBodyData={diseaseBodyData}
-/>
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        selectedCategory={selectedCategory}
+        onCategoryChange={setSelectedCategory}
+        symptomData={symptomData?.data}
+        symptomBodyData={symptomBodyData}
+        diseaseData={diseaseData?.data}
+        diseaseBodyData={diseaseBodyData}
+      />
     </div>
   );
 };

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -38,9 +38,9 @@ const Step2 = () => {
   const handleNext = () => console.log("다음 구현 예정");
 
   return (
-    <>
+    <div className={styles.backgroundColor}>
       <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack />} />
-      <div className={styles.wrapper}>
+      <section className={styles.wrapper}>
         <ReviewSymptom
           onCategoryChange={handleOpenBottomSheet}
           symptomBodyData={symptomBodyData}
@@ -48,11 +48,11 @@ const Step2 = () => {
         />
         <ReviewPurpose />
         <ReviewDisease onCategoryChange={handleOpenBottomSheet} diseaseBodyData={diseaseBodyData} />
-      </div>
-      <div className={styles.btnLayout}>
+      </section>
+      <section className={styles.btnLayout}>
         <Button label="이전으로" size="large" variant="solidNeutral" onClick={handleGoBack} />
         <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} />
-      </div>
+      </section>
       <SearchSymptomDisease
         isOpen={open}
         onClose={() => setOpen(false)}
@@ -61,7 +61,7 @@ const Step2 = () => {
         symptomBodyData={symptomBodyData}
         diseaseBodyData={diseaseBodyData}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -54,13 +54,15 @@ const Step2 = () => {
         <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} />
       </section>
       <SearchSymptomDisease
-        isOpen={open}
-        onClose={() => setOpen(false)}
-        selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
-        symptomBodyData={symptomBodyData}
-        diseaseBodyData={diseaseBodyData}
-      />
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  selectedCategory={selectedCategory}
+  onCategoryChange={setSelectedCategory}
+  symptomData={symptomData?.data}
+  symptomBodyData={symptomBodyData}
+  diseaseData={diseaseData?.data}
+  diseaseBodyData={diseaseBodyData}
+/>
     </div>
   );
 };

--- a/src/app/review/write/_section/Step2.tsx
+++ b/src/app/review/write/_section/Step2.tsx
@@ -1,0 +1,41 @@
+import HeaderNav from "@common/component/HeaderNav/HeaderNav";
+import { IcDeleteBlack } from "@asset/svg/index";
+import ReviewSymptom from "@app/review/write/_component/ReviewSymptom";
+import ReviewPurpose from "@app/review/write/_component/ReviewPurpose";
+import ReviewDisease from "@app/review/write/_component/ReviewDisease";
+import * as styles from "./Step2.style.css";
+import { Button } from "@common/component/Button";
+
+const handleGoBack = () => {
+  console.log("뒤로가기 구현 예정");
+};
+
+const handleNext = () => {
+  console.log("다음 구현 예정, 활성화도!");
+};
+
+const Step2 = () => {
+  return (
+    <>
+      {/* 상단 헤더 */}
+      <HeaderNav centerContent="리뷰작성(2/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
+      <div className={styles.wrapper}>
+        {/* 2-1. 증상 */}
+        <ReviewSymptom />
+
+        {/* 2-2. 방문 목적 */}
+        <ReviewPurpose />
+
+        {/* 2-3. 진단 내용 */}
+        <ReviewDisease />
+      </div>
+      {/* 하단 버튼 */}
+      <div className={styles.btnLayout}>
+        <Button label="이전으로" size="large" variant="solidNeutral" disabled={false} onClick={handleGoBack} />
+        <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} onClick={handleNext} />
+      </div>
+    </>
+  );
+};
+
+export default Step2;

--- a/src/app/review/write/_utils/getNameById.ts
+++ b/src/app/review/write/_utils/getNameById.ts
@@ -1,0 +1,22 @@
+interface Item {
+  id?: number;
+  name?: string;
+}
+
+interface BodyData {
+  bodies?: {
+    id?: number;
+    name?: string;
+    symptoms?: Item[];
+    diseases?: Item[];
+  }[];
+}
+
+export const getNameById = (id: number, symptomBodyData?: BodyData, diseaseBodyData?: BodyData): string => {
+  const allItems = [
+    ...(symptomBodyData?.bodies?.flatMap((b) => b.symptoms ?? []) ?? []),
+    ...(diseaseBodyData?.bodies?.flatMap((b) => b.diseases ?? []) ?? []),
+  ];
+
+  return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
+};

--- a/src/app/review/write/_utils/getNameById.ts
+++ b/src/app/review/write/_utils/getNameById.ts
@@ -1,22 +1,12 @@
-interface Item {
-  id?: number;
-  name?: string;
-}
+import { symptomGetResponse } from "@api/domain/register-pet/symptom";
+import { diseaseGetResponse } from "@api/domain/register-pet/disease";
 
-interface BodyData {
-  bodies?: {
-    id?: number;
-    name?: string;
-    symptoms?: Item[];
-    diseases?: Item[];
-  }[];
-}
+export const getSymptomNameById = (id: number, symptomBodyData?: symptomGetResponse["data"]): string => {
+  const symptom = [...(symptomBodyData?.bodies?.flatMap((b) => b.symptoms ?? []) ?? [])];
+  return symptom.find((item) => item.id === id)?.name ?? "알 수 없음";
+};
+export const getDiseaseNameById = (id: number, diseaseBodyData?: diseaseGetResponse["data"]): string => {
+  const disease = diseaseBodyData?.bodies?.flatMap((body) => body.diseases ?? []).find((d) => d.id === id);
 
-export const getNameById = (id: number, symptomBodyData?: BodyData, diseaseBodyData?: BodyData): string => {
-  const allItems = [
-    ...(symptomBodyData?.bodies?.flatMap((b) => b.symptoms ?? []) ?? []),
-    ...(diseaseBodyData?.bodies?.flatMap((b) => b.diseases ?? []) ?? []),
-  ];
-
-  return allItems.find((item) => item.id === id)?.name ?? "알 수 없음";
+  return disease?.name ?? "알 수 없음";
 };

--- a/src/app/review/write/constant.ts
+++ b/src/app/review/write/constant.ts
@@ -1,0 +1,2 @@
+// ReviewPurpose
+export const PURPOSE_LABELS = ["증상 진단 및 상담", "수술", "예방접종", "건강검진", "기타(미용 등)"];

--- a/src/app/review/write/constant.ts
+++ b/src/app/review/write/constant.ts
@@ -1,2 +1,0 @@
-// ReviewPurpose
-export const PURPOSE_LABELS = ["증상 진단 및 상담", "수술", "예방접종", "건강검진", "기타(미용 등)"];

--- a/src/app/review/write/page.tsx
+++ b/src/app/review/write/page.tsx
@@ -1,16 +1,33 @@
 "use client";
 
+import { FormProvider, useForm } from "react-hook-form";
+
 // import Step1 from "@app/review/write/_section/Step1";
 import Step2 from "@app/review/write/_section/Step2";
-import { FormProvider, useForm } from "react-hook-form";
+
+// 제출할 리뷰 데이터
 export interface ReviewFormData {
-  hospital: string;
-  date: string;
+  hospital: string; // ⚠️ 이거 필요없음
+  date: string; // ⚠️ 키 visitedAt으로 바꿔야함
+  symptomIds: number[];
+  diseaseId: number; 
+  // breedId:number;
+  // gender: string;
+  // weight: number;
+  // visitedAt: string
+  // content: string;
+  // purposeId: number;
+  // diseaseId: number;
+  // goodReviewIds: number[];
+  // badReviewIds: number[];
+  // images: string[];
 }
 
 const defaultValues: ReviewFormData = {
   hospital: "",
   date: "",
+  symptomIds: [],
+  diseaseId: -1,
 };
 
 const page = () => {

--- a/src/app/review/write/page.tsx
+++ b/src/app/review/write/page.tsx
@@ -1,72 +1,29 @@
 "use client";
 
-import { useState } from "react";
-import { IcDeleteBlack } from "@asset/svg/index";
-import * as styles from "./styles.css";
+// import Step1 from "@app/review/write/_section/Step1";
+import Step2 from "@app/review/write/_section/Step2";
+import { FormProvider, useForm } from "react-hook-form";
+export interface ReviewFormData {
+  hospital: string;
+  date: string;
+}
 
-import HeaderNav from "@common/component/HeaderNav/HeaderNav";
-import ReviewHospital from "@app/review/write/_component/ReviewHospital";
-import ReviewDate from "@app/review/write/_component/ReviewDate";
-import ReviewPetInfo from "@app/review/write/_component/ReviewPetInfo";
-import SearchHospital, { Hospital } from "@shared/component/SearchHospital/SearchHospital";
-import { Button } from "@common/component/Button/index";
-
-export type PetInfoType = "myPet" | "manual";
-
-const Page = () => {
-  // 병원 검색 바텀시트 열고 닫기
-  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-  // 선택된 병원
-  const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
-  // 동물 정보 입력 방법 선택
-  const [selectedPetInfo, setSelectedPetInfo] = useState<PetInfoType | null>(null);
-
-  // 1-1. hospital ⚠️ 나갈 수 있는 방법이 2가지라 분리
-  const handleOpenSearchHospital = () => {
-    setIsBottomSheetOpen(true);
-  };
-  const handleCloseBottomSheet = () => {
-    setIsBottomSheetOpen(false);
-  };
-
-  const handleSelectHospital = (hospital: Hospital | null) => {
-    setSelectedHospital(hospital);
-  };
-
-  // 1-3. petInfo
-  const handleSelectPetInfo = (type: PetInfoType) => {
-    setSelectedPetInfo((prev) => (prev === type ? null : type));
-  };
-
-  return (
-    <div className={styles.preventScroll}>
-      {/* 상단 헤더 */}
-      <HeaderNav centerContent="리뷰작성(1/4)" leftIcon={<IcDeleteBlack style={{ width: 24, height: 24 }} />} />
-
-      {/* 중앙 컨텐츠 */}
-      <div className={styles.wrapper}>
-        {/* 1-1. 병원 검색 */}
-        <ReviewHospital selectedHospital={selectedHospital} handleOpenSearchHospital={handleOpenSearchHospital} />
-        {/* 1-2. 날짜 선택 */}
-        <ReviewDate />
-        {/* 1-3. 동물 정보 */}
-        <ReviewPetInfo selectedPetInfo={selectedPetInfo} onSelectPetInfo={handleSelectPetInfo} />
-      </div>
-
-      {/* 하단 버튼 */}
-      <div className={styles.buttonContainer}>
-        <Button label="다음으로" size="large" variant="solidPrimary" disabled={true} />
-      </div>
-
-      {/* 병원 검색 바텀시트 */}
-      <SearchHospital
-        active={isBottomSheetOpen}
-        onCloseBottomSheet={handleCloseBottomSheet}
-        selectedHospital={selectedHospital}
-        onSelectHospital={handleSelectHospital}
-      />
-    </div>
-  );
+const defaultValues: ReviewFormData = {
+  hospital: "",
+  date: "",
 };
 
-export default Page;
+const page = () => {
+  const methods = useForm<ReviewFormData>({
+    defaultValues,
+    mode: "onChange",
+  });
+
+  return (
+    <FormProvider {...methods}>
+      {/* <Step1 /> */}
+      <Step2 />
+    </FormProvider>
+  );
+};
+export default page;

--- a/src/app/review/write/page.tsx
+++ b/src/app/review/write/page.tsx
@@ -7,16 +7,16 @@ import Step2 from "@app/review/write/_section/Step2";
 
 // 제출할 리뷰 데이터
 export interface ReviewFormData {
-  hospital: string; // ⚠️ 이거 필요없음
+  hospital: string; // ⚠️ 이거 필요없음 다른 pr 머지되면 수정 예정
   date: string; // ⚠️ 키 visitedAt으로 바꿔야함
   symptomIds: number[];
-  diseaseId: number; 
+  diseaseId: number;
+  purposeId: number;
   // breedId:number;
   // gender: string;
   // weight: number;
   // visitedAt: string
   // content: string;
-  // purposeId: number;
   // diseaseId: number;
   // goodReviewIds: number[];
   // badReviewIds: number[];
@@ -28,6 +28,7 @@ const defaultValues: ReviewFormData = {
   date: "",
   symptomIds: [],
   diseaseId: -1,
+  purposeId: -1,
 };
 
 const page = () => {

--- a/src/asset/svg/IcReviewRightIcon.tsx
+++ b/src/asset/svg/IcReviewRightIcon.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import type { SVGProps } from "react";
+const SvgIcReviewRightIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 20 20"
+    {...props}
+  >
+    <path
+      stroke="#3DC4F5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="m14.167 5.834-8.333 8.333m0-8.333 8.333 8.333"
+    />
+  </svg>
+);
+export default SvgIcReviewRightIcon;

--- a/src/asset/svg/index.ts
+++ b/src/asset/svg/index.ts
@@ -45,6 +45,7 @@ export { default as IcOut } from "./IcOut";
 export { default as IcPlus } from "./IcPlus";
 export { default as IcPostImageSkeleton } from "./IcPostImageSkeleton";
 export { default as IcReview } from "./IcReview";
+export { default as IcReviewRightIcon } from "./IcReviewRightIcon";
 export { default as IcReviewoff } from "./IcReviewoff";
 export { default as IcReviewon } from "./IcReviewon";
 export { default as IcRightArror } from "./IcRightArror";

--- a/src/common/component/BottomSheet/BottomSheet.css.ts
+++ b/src/common/component/BottomSheet/BottomSheet.css.ts
@@ -3,11 +3,14 @@ import { style } from "@vanilla-extract/css";
 
 export const overlay = style({
   position: "fixed",
-  top: 0,
-  left: 0,
+  bottom: "0",
+  left: "0",
+  right: "0",
   zIndex: "99",
 
   width: "100%",
+  maxWidth: "76.8rem",
+  margin: "0 auto",
   height: "100%",
   backgroundColor: "rgba(34, 34, 34, 0.2)",
 });
@@ -15,12 +18,17 @@ export const overlay = style({
 export const bottomSheet = style({
   position: "absolute",
   bottom: "0",
+  left: "0",
+  right: "0",
 
   display: "flex",
   flexDirection: "column",
   zIndex: "99",
 
   width: "100%",
+  maxWidth: "76.8rem",
+  margin: "0 auto",
+
   height: "90vh",
   borderRadius: "20px 20px 0px 0px",
   backgroundColor: "white",

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -12,16 +12,40 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * 최근 검색어 조회 API
-         * @description 최근 검색어를 조회하는 API입니다.
+         * 최근 커뮤니티 검색어 조회 API
+         * @description 최근 커뮤니티 검색어를 조회하는 API입니다.
          */
         get: operations["getSearch"];
         put?: never;
         /**
-         * 최근 검색어 저장 API
-         * @description 최근 검색어를 저장하는 API입니다.
+         * 최근 커뮤니티 검색어 저장 API
+         * @description 최근 커뮤니티 검색어를 저장하는 API입니다.
          */
         post: operations["addSearch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/search/hospital": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 최근 병원 검색어 조회 API
+         * @description 최근 병원 검색어를 조회하는 API입니다.
+         */
+        get: operations["getHospitalSearch"];
+        put?: never;
+        /**
+         * 최근 병원 검색어 저장 API
+         * @description 최근 병원 검색어를 저장하는 API입니다.
+         */
+        post: operations["addHospitalSearch"];
         delete?: never;
         options?: never;
         head?: never;
@@ -156,6 +180,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dev/hospitals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 병원 리스트 조회 API
+         * @description 병원 검색, 메인 페이지 등에서 정렬 기준에 따라 병원 리스트를 조회할 때 사용하는 API입니다.
+         */
+        post: operations["getHospitals"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/{hospitalId}/reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 리뷰 작성 API
+         * @description 병원 리뷰를 작성하는 API입니다.
+         */
+        post: operations["addReview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/reviews/filter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 리뷰 리스트 조회 API
+         * @description 메인페이지 리뷰 리스트 조회 & 병원 리뷰 리스트 조회 API입니다.
+         */
+        post: operations["getHospitalReviewList"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dev/comments/{postId}": {
         parameters: {
             query?: never;
@@ -242,6 +326,50 @@ export interface paths {
          * @description 사용자를 정보 업데이트 API 입니다.
          */
         patch: operations["updateMemberProfile"];
+        trace?: never;
+    };
+    "/api/dev/members/reviews/agree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 리뷰 약관 동의 여부 조회 API
+         * @description 리뷰 약관 동의 여부를 조회하는 API입니다.
+         */
+        get: operations["getMemberReviewTerms"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 리뷰 약관 동의 업데이트 API
+         * @description 리뷰 약관 동의 여부를 업데이트하는 API입니다.
+         */
+        patch: operations["updateMemberReviewTerms"];
+        trace?: never;
+    };
+    "/api/dev/members/hospitals/{hospitalId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 사용자 즐겨찾는 병원 추가&수정 API
+         * @description 사용자의 즐겨찾는 병원을 수정합니다. 이전에 등록된 병원이 없는 경우 추가합니다.
+         */
+        patch: operations["updateMemberHospital"];
         trace?: never;
     };
     "/api/dev/test/token-valid": {
@@ -424,6 +552,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dev/members/location": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사용자 위치 조회 API
+         * @description 사용자위치에 등록된 동 정보를 반환합니다.
+         */
+        get: operations["getMemberLocation"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/members/hospitals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사용자 즐겨찾는 병원 조회 API
+         * @description 사용자의 즐겨찾는 병원을 조회합니다. 없으면 보내지 않습니다.
+         */
+        get: operations["getMemberHospital"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dev/members/check": {
         parameters: {
             query?: never;
@@ -436,6 +604,126 @@ export interface paths {
          * @description 중복된 닉네임이 있는지 검사합니다.
          */
         get: operations["checkNickname"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/locations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 지역 조회 API
+         * @description 전체 지역을 조회하는 API 입니다.
+         */
+        get: operations["getLocations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/{hospitalId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 병원 상세 조회 API
+         * @description 병원 상세 정보 조회 API입니다.
+         */
+        get: operations["getHospitalDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/{hospitalId}/reviews/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 리뷰 요약 조회 API
+         * @description 병원 리뷰 요약 리스트를 조회하는 API입니다.
+         */
+        get: operations["getReviewSummaryList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/reviews/summary/option": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 리뷰 요약 옵션 리스트 조회 API
+         * @description 병원 리뷰 요약 옵션 리스트를 조회하는 API입니다.
+         */
+        get: operations["getReviewSummaryOptionList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/reviews/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 사용자 리뷰 리스트 조회 API
+         * @description 마이페이지 리뷰 리스트 조회 API입니다.
+         */
+        get: operations["getMemberHospitalReviewList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/purposes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 병원 방문 목적 리스트 조회 API
+         * @description 병원 방문 목적 리스트 조회 API입니다.
+         */
+        get: operations["getHospitalVisitPurposeList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -539,6 +827,42 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/members/deactivate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: operations["deactivateMember"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dev/hospitals/reviews/{reviewId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 리뷰 삭제 API
+         * @description 리뷰를 삭제하는 API입니다.
+         */
+        delete: operations["deleteReview"];
         options?: never;
         head?: never;
         patch?: never;
@@ -715,6 +1039,12 @@ export interface components {
              * @example YYYY-MM-DD~ or null
              */
             createdAt?: string;
+            /**
+             * Format: int64
+             * @description 신체 아이디
+             * @example 1
+             */
+            bodyId?: number;
         };
         BaseResponsePostListResponse: {
             /** Format: int32 */
@@ -879,6 +1209,353 @@ export interface components {
              */
             refreshToken?: string;
         };
+        HospitalListRequest: {
+            /**
+             * @description 지역 타입
+             * @example CITY
+             * @enum {string}
+             */
+            locationType?: "CITY" | "DISTRICT";
+            /**
+             * Format: int64
+             * @description 지역 아이디
+             * @example 1
+             */
+            locationId?: number;
+            /**
+             * Format: int64
+             * @description 마지막으로 조회된 병원 아이디 (첫 요청을 제외하고 필수로 보내야 합니다.)
+             * @example 1
+             */
+            cursorId?: number;
+            /**
+             * Format: int32
+             * @description 마지막으로 조회된 병원 리뷰수 (정렬 기준이 REVIEW일 때는 첫 요청을 제외하고 필수로 보내야 합니다.)
+             * @example 1
+             */
+            cursorReviewCount?: number;
+            /**
+             * Format: int32
+             * @description 병원 요청 수
+             * @example 10
+             */
+            size?: number;
+            /**
+             * @description 검색어
+             * @example 병원
+             */
+            keyword?: string;
+            /**
+             * @description 정렬 기준
+             * @example REVIEW
+             * @enum {string}
+             */
+            sortBy?: "REVIEW";
+        };
+        BaseResponseHospitalListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["HospitalListResponse"];
+        };
+        HospitalListResponse: {
+            /**
+             * Format: int64
+             * @description 리스트의 마지막 병원 아이디
+             * @example 1
+             */
+            cursorId?: number;
+            /**
+             * Format: int32
+             * @description 리스트의 마지막 병원 리뷰수
+             * @example 1
+             */
+            cursorReviewCount?: number;
+            /** @description 병원 리스트 */
+            hospitals?: components["schemas"]["HospitalResponse"][];
+        };
+        HospitalResponse: {
+            /**
+             * Format: int64
+             * @description 병원 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 병원명
+             * @example 코코스동물병원
+             */
+            name?: string;
+            /**
+             * @description 주소
+             * @example 서울시 강남구
+             */
+            address?: string;
+            /**
+             * Format: int32
+             * @description 리뷰수
+             * @example 777
+             */
+            reviewCount?: number;
+            /**
+             * @description 이미지
+             * @example 이미지 url
+             */
+            image?: string;
+        };
+        ReviewAddRequest: {
+            /**
+             * Format: int64
+             * @description 종 아이디
+             * @example 1
+             */
+            breedId?: number;
+            /**
+             * @description 성별
+             * @example F | M
+             * @enum {string}
+             */
+            gender?: "M" | "F";
+            /**
+             * Format: int32
+             * @description 몸무게
+             * @example 5
+             */
+            weight?: number;
+            /**
+             * @description 방문 날짜
+             * @example 2025.04.22
+             */
+            visitedAt?: string;
+            /**
+             * @description 내용
+             * @example 병원 시설이 너무 깔끔해요.
+             */
+            content?: string;
+            /**
+             * Format: int64
+             * @description 방문 목적 아이디
+             * @example 1
+             */
+            purposeId?: number;
+            /**
+             * Format: int64
+             * @description 질병 아이디
+             * @example 7
+             */
+            diseaseId?: number;
+            /**
+             * @description 증상 아이디 리스트
+             * @example [5,30...]
+             */
+            symptomIds?: number[];
+            /**
+             * @description 좋은 간단 리뷰 아이디 리스트
+             * @example [1,2,3...]
+             */
+            goodReviewIds?: number[];
+            /**
+             * @description 나쁜 간단 리뷰 아이디 리스트
+             * @example [1,2,3...]
+             */
+            badReviewIds?: number[];
+            /**
+             * @description 리뷰 이미지 리스트
+             * @example [image1, image2...]
+             */
+            images?: string[];
+        };
+        BaseResponseReviewAddResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["ReviewAddResponse"];
+        };
+        ReviewAddResponse: {
+            /**
+             * @description 리뷰 이미지 presigned url
+             * @example [https://~, https://~]
+             */
+            images?: string[];
+        };
+        ReviewListRequest: {
+            /**
+             * Format: int64
+             * @description 리뷰 요약 아이디
+             * @example 1
+             */
+            summaryOptionId?: number;
+            /**
+             * Format: int64
+             * @description 커서 아이디 (마지막으로 전달받은 리뷰 아이디
+             * @example 1
+             */
+            cursorId?: number;
+            /**
+             * Format: int64
+             * @description 병원 아이디
+             * @example 1
+             */
+            hospitalId?: number;
+            /**
+             * Format: int64
+             * @description 신체 아이디
+             * @example 1
+             */
+            bodyId?: number;
+            /**
+             * Format: int64
+             * @description 지역 아이디
+             * @example 1
+             */
+            locationId?: number;
+            /**
+             * @description 지역 타입
+             * @example DISTRICT
+             * @enum {string}
+             */
+            locationType?: "CITY" | "DISTRICT";
+            /**
+             * Format: int32
+             * @description 페이지네이션 크기
+             * @default 10
+             * @example 10
+             */
+            size: number;
+        };
+        BaseResponseHospitalReviewListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["HospitalReviewListResponse"];
+        };
+        HospitalReviewListResponse: {
+            /**
+             * Format: int32
+             * @description 리뷰수
+             * @example 111
+             */
+            reviewCount?: number;
+            /**
+             * Format: int64
+             * @description 커서 아이디 (현재 응답 값의 마지막 리뷰 아이디)
+             * @example 12
+             */
+            cursorId?: number;
+            reviews?: components["schemas"]["HospitalReviewResponse"][];
+        };
+        /** @description 리뷰 정보 */
+        HospitalReviewResponse: {
+            /**
+             * Format: int64
+             * @description 리뷰 ID
+             * @example 1
+             */
+            id?: number;
+            /**
+             * Format: int64
+             * @description 작성자 아이디
+             * @example 1
+             */
+            memberId?: number;
+            /**
+             * @description 작성자 닉네임
+             * @example 냥냥
+             */
+            nickname?: string;
+            /**
+             * @description 종 이름
+             * @example 말티즈
+             */
+            memberBreed?: string;
+            /**
+             * Format: int32
+             * @description 펫 나이
+             * @example 1
+             */
+            age?: number;
+            /**
+             * Format: int64
+             * @description 병원 아이디
+             * @example 1
+             */
+            hospitalId?: number;
+            /**
+             * @description 병원 이름
+             * @example 코코병원
+             */
+            hospitalName?: string;
+            /**
+             * @description 방문 일자
+             * @example 2020.02.02
+             */
+            visitedAt?: string;
+            /**
+             * @description 병원 주소
+             * @example 서울시 강남구
+             */
+            hospitalAddress?: string;
+            /**
+             * @description 리뷰 본문
+             * @example 좋았다.
+             */
+            content?: string;
+            /** @description 리뷰 요약 옵션 리스트 */
+            reviewSummary?: components["schemas"]["ReviewSummaryOptionListResponse"];
+            /** @description 리뷰 이미지 리스트 */
+            images?: string[];
+            /**
+             * @description 증상 리스트
+             * @example 배가 아파요
+             */
+            symptoms?: string[];
+            /**
+             * @description 질병 이름
+             * @example 심장병
+             */
+            disease?: string;
+            /**
+             * @description 동물 이름
+             * @example 강아지
+             */
+            animal?: string;
+            /**
+             * @description 성별
+             * @example F
+             * @enum {string}
+             */
+            gender?: "M" | "F";
+            /**
+             * @description 종 이름
+             * @example 말티즈
+             */
+            breed?: string;
+            /**
+             * Format: double
+             * @description 몸무게
+             * @example 2.7
+             */
+            weight?: number;
+        };
+        ReviewSummaryOptionListResponse: {
+            /** @description 좋은 리뷰 요약 리스트 */
+            goodReviews?: components["schemas"]["ReviewSummaryOptionResponse"][];
+            /** @description 나쁜 리뷰 요약 리스트 */
+            badReviews?: components["schemas"]["ReviewSummaryOptionResponse"][];
+        };
+        ReviewSummaryOptionResponse: {
+            /**
+             * Format: int64
+             * @description 리뷰 요약 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 리뷰 요약 내용
+             * @example ~게 너무 좋았어요!
+             */
+            label?: string;
+        };
         CommentContentRequest: {
             /**
              * @description 댓글 내용
@@ -941,6 +1618,62 @@ export interface components {
              *     ]
              */
             symptomIds?: number[];
+        };
+        ProfileUpdateRequest: {
+            /**
+             * @description 닉네임
+             * @example 코코스
+             */
+            nickname?: string;
+            /**
+             * @description 주소
+             * @example ~시 ~구 ~동
+             */
+            address?: string;
+            /**
+             * @description 도로명 주소
+             * @example ~시 ~로 ~번길
+             */
+            roadAddress?: string;
+            /**
+             * @description 시/도 이름
+             * @example 경기도
+             */
+            cityName?: string;
+            /**
+             * @description 시/군/구
+             * @example 평택시
+             */
+            districtName?: string;
+            /**
+             * @description 읍/면/동
+             * @example 비전2동
+             */
+            townName?: string;
+            /**
+             * Format: double
+             * @description 위도
+             * @example 35.xxxx
+             */
+            latitude?: number;
+            /**
+             * Format: double
+             * @description 경도
+             * @example 128.xxx
+             */
+            longitude?: number;
+            /**
+             * Format: int64
+             * @description 위치 아이디
+             * @example 1
+             */
+            locationId?: number;
+            /**
+             * @description 위치 종류
+             * @example CITY | DISTRICT
+             * @enum {string}
+             */
+            locationType?: "CITY" | "DISTRICT";
         };
         BaseResponseNicknameExistenceResponse: {
             /** Format: int32 */
@@ -1331,6 +2064,19 @@ export interface components {
              */
             profileImage?: string;
         };
+        BaseResponseMemberReviewTermsAgreeResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberReviewTermsAgreeResponse"];
+        };
+        MemberReviewTermsAgreeResponse: {
+            /**
+             * @description 리뷰 약관 동의 여부
+             * @example true
+             */
+            isReviewTermsAgree?: boolean;
+        };
         BaseResponseReissueTokenResponse: {
             /** Format: int32 */
             code?: number;
@@ -1340,6 +2086,262 @@ export interface components {
         ReissueTokenResponse: {
             /** @description 토큰 */
             tokens?: components["schemas"]["TokenResponse"];
+        };
+        BaseResponseMemberLocationResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberLocationResponse"];
+        };
+        /**
+         * @description 회원 위치 응답 예시
+         * @example {
+         *       "locationId": 1,
+         *       "locationName": "서울특별시",
+         *       "locationType": "CITY"
+         *     }
+         */
+        MemberLocationResponse: {
+            /**
+             * Format: int64
+             * @description 위치 아이디
+             * @example 1
+             */
+            locationId?: number;
+            /**
+             * @description 위치 이름
+             * @example 서울특별시
+             */
+            locationName?: string;
+            /**
+             * @description 위치 타입
+             * @example CITY | DISTRICT
+             */
+            locationType?: string;
+        };
+        BaseResponseMemberHospitalResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberHospitalResponse"];
+        };
+        MemberHospitalResponse: {
+            /**
+             * Format: int64
+             * @description 병원 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 병원 이름
+             * @example 코코스 동물병원
+             */
+            name?: string;
+            /**
+             * @description 병원 주소
+             * @example 서울시 강남구 테헤란로
+             */
+            address?: string;
+        };
+        BaseResponseLocationResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["LocationResponse"];
+        };
+        CityResponse: {
+            /** Format: int64 */
+            id?: number;
+            name?: string;
+            districts?: components["schemas"]["DistrictResponse"][];
+        };
+        DistrictResponse: {
+            /** Format: int64 */
+            id?: number;
+            name?: string;
+        };
+        LocationResponse: {
+            cities?: components["schemas"]["CityResponse"][];
+        };
+        BaseResponseHospitalDetailResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["HospitalDetailResponse"];
+        };
+        HospitalDetailResponse: {
+            /**
+             * @description 병원 이름
+             * @example 코코스 동물병원
+             */
+            name?: string;
+            /**
+             * @description 병원 전화번호
+             * @example 02-1234-5671
+             */
+            phoneNumber?: string;
+            /**
+             * @description 병원 태그
+             * @example [강아지, 심장병]
+             */
+            tags?: string[];
+            /**
+             * @description 병원 소개
+             * @example 이 동물병원은 지상 최고의 동물병원입니다.
+             */
+            introduction?: string;
+            /**
+             * @description 병원 주소
+             * @example 서울특별시 강남구 논현동
+             */
+            address?: string;
+            /**
+             * @description 병원 이미지
+             * @example https://www.~~
+             */
+            image?: string;
+        };
+        BaseResponseReviewSummaryListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["ReviewSummaryListResponse"];
+        };
+        ReviewSummaryListResponse: {
+            /** @description 좋은 리뷰 요약 리스트 */
+            goodReviews?: components["schemas"]["ReviewSummaryResponse"][];
+            /** @description 나쁜 리뷰 요약 리스트 */
+            badReviews?: components["schemas"]["ReviewSummaryResponse"][];
+        };
+        ReviewSummaryResponse: {
+            /**
+             * Format: int64
+             * @description 리뷰 요약 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 리뷰 요약 내용
+             * @example ~게 너무 좋았어요!
+             */
+            label?: string;
+            /**
+             * Format: int32
+             * @description 리뷰 요약 개수
+             * @example 10
+             */
+            count?: number;
+        };
+        BaseResponseReviewSummaryOptionListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["ReviewSummaryOptionListResponse"];
+        };
+        BaseResponseMemberHospitalReviewListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["MemberHospitalReviewListResponse"];
+        };
+        MemberHospitalReviewListResponse: {
+            /** Format: int64 */
+            cursorId?: number;
+            reviews?: components["schemas"]["MemberHospitalReviewResponse"][];
+        };
+        /** @description 리뷰 정보 */
+        MemberHospitalReviewResponse: {
+            /**
+             * Format: int64
+             * @description 리뷰 ID
+             * @example 1
+             */
+            id?: number;
+            /**
+             * Format: int64
+             * @description 병원 아이디
+             * @example 1
+             */
+            hospitalId?: number;
+            /**
+             * @description 병원 이름
+             * @example 코코병원
+             */
+            hospitalName?: string;
+            /**
+             * @description 방문 일자
+             * @example 2020.02.02
+             */
+            visitedAt?: string;
+            /**
+             * @description 병원 주소
+             * @example 서울시 강남구
+             */
+            hospitalAddress?: string;
+            /**
+             * @description 리뷰 본문
+             * @example 좋았다.
+             */
+            content?: string;
+            /** @description 리뷰 요약 옵션 리스트 */
+            reviewSummary?: components["schemas"]["ReviewSummaryOptionListResponse"];
+            /** @description 리뷰 이미지 리스트 */
+            images?: string[];
+            /**
+             * @description 증상 리스트
+             * @example 배가 아파요
+             */
+            symptoms?: string[];
+            /**
+             * @description 질병 이름
+             * @example 심장병
+             */
+            disease?: string;
+            /**
+             * @description 동물 이름
+             * @example 강아지
+             */
+            animal?: string;
+            /**
+             * @description 성별
+             * @example F
+             * @enum {string}
+             */
+            gender?: "M" | "F";
+            /**
+             * @description 종 이름
+             * @example 말티즈
+             */
+            breed?: string;
+            /**
+             * Format: double
+             * @description 몸무게
+             * @example 2.7
+             */
+            weight?: number;
+        };
+        BaseResponseHospitalVisitPurposeListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["HospitalVisitPurposeListResponse"];
+        };
+        HospitalVisitPurposeListResponse: {
+            /** @description 병원 방문 목적 리스트 */
+            purposes?: components["schemas"]["HospitalVisitPurposeResponse"][];
+        };
+        HospitalVisitPurposeResponse: {
+            /**
+             * Format: int64
+             * @description 병원 방문 목적 아이디
+             * @example 1
+             */
+            id?: number;
+            /**
+             * @description 병원 방문 목적
+             * @example 진료
+             */
+            label?: string;
         };
         BaseResponseDiseasesOfBodiesResponse: {
             /** Format: int32 */
@@ -1651,6 +2653,19 @@ export interface components {
             message?: string;
             data?: components["schemas"]["AnimalsResponse"];
         };
+        BaseResponseReviewImageDeleteListResponse: {
+            /** Format: int32 */
+            code?: number;
+            message?: string;
+            data?: components["schemas"]["ReviewImageDeleteListResponse"];
+        };
+        ReviewImageDeleteListResponse: {
+            /**
+             * @description 리뷰 삭제 presigned url
+             * @example [https://~, https://~]
+             */
+            images?: string[];
+        };
     };
     responses: never;
     parameters: never;
@@ -1669,7 +2684,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description 최근 검색어 조회 성공 */
+            /** @description 최근 커뮤니티 검색어 조회 성공 */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -1692,7 +2707,50 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description 최근 검색어 저장 성공 */
+            /** @description 최근 커뮤니티 검색어 저장 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseVoid"];
+                };
+            };
+        };
+    };
+    getHospitalSearch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 최근 병원 검색어 조회 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseSearchResponse"];
+                };
+            };
+        };
+    };
+    addHospitalSearch: {
+        parameters: {
+            query: {
+                /** @description 검색어 */
+                keyword: unknown;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 최근 병원 검색어 저장 성공 */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -1887,6 +2945,81 @@ export interface operations {
             };
         };
     };
+    getHospitals: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HospitalListRequest"];
+            };
+        };
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseHospitalListResponse"];
+                };
+            };
+        };
+    };
+    addReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 병원 아이디 */
+                hospitalId: unknown;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReviewAddRequest"];
+            };
+        };
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseReviewAddResponse"];
+                };
+            };
+        };
+    };
+    getHospitalReviewList: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReviewListRequest"];
+            };
+        };
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseHospitalReviewListResponse"];
+                };
+            };
+        };
+    };
     getPostComments: {
         parameters: {
             query?: never;
@@ -2015,14 +3148,16 @@ export interface operations {
     };
     updateMemberProfile: {
         parameters: {
-            query: {
-                nickname: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
         responses: {
             /** @description 요청에 성공했습니다.  */
             200: {
@@ -2031,6 +3166,68 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["BaseResponseNicknameExistenceResponse"];
+                };
+            };
+        };
+    };
+    getMemberReviewTerms: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberReviewTermsAgreeResponse"];
+                };
+            };
+        };
+    };
+    updateMemberReviewTerms: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseVoid"];
+                };
+            };
+        };
+    };
+    updateMemberHospital: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                hospitalId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseVoid"];
                 };
             };
         };
@@ -2247,6 +3444,48 @@ export interface operations {
             };
         };
     };
+    getMemberLocation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다.  */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberLocationResponse"];
+                };
+            };
+        };
+    };
+    getMemberHospital: {
+        parameters: {
+            query?: {
+                nickname?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberHospitalResponse"];
+                };
+            };
+        };
+    };
     checkNickname: {
         parameters: {
             query: {
@@ -2265,6 +3504,139 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["BaseResponseNicknameExistenceResponse"];
+                };
+            };
+        };
+    };
+    getLocations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseLocationResponse"];
+                };
+            };
+        };
+    };
+    getHospitalDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 병원 아이디 */
+                hospitalId: unknown;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseHospitalDetailResponse"];
+                };
+            };
+        };
+    };
+    getReviewSummaryList: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 병원 아이디 */
+                hospitalId: unknown;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseReviewSummaryListResponse"];
+                };
+            };
+        };
+    };
+    getReviewSummaryOptionList: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseReviewSummaryOptionListResponse"];
+                };
+            };
+        };
+    };
+    getMemberHospitalReviewList: {
+        parameters: {
+            query?: {
+                /** @description 사용자 닉네임 */
+                nickname?: string;
+                /** @description 페이징용 마지막 리뷰 ID */
+                cursorId?: number;
+                /** @description 페이지당 조회할 리뷰 개수 (1~20) 비로그인 시 최대 4개 */
+                size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseMemberHospitalReviewListResponse"];
+                };
+            };
+        };
+    };
+    getHospitalVisitPurposeList: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseHospitalVisitPurposeListResponse"];
                 };
             };
         };
@@ -2379,6 +3751,49 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["BaseResponseAnimalsResponse"];
+                };
+            };
+        };
+    };
+    deactivateMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseVoid"];
+                };
+            };
+        };
+    };
+    deleteReview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 리뷰 아이디 */
+                reviewId: unknown;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 요청에 성공했습니다. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["BaseResponseReviewImageDeleteListResponse"];
                 };
             };
         };


### PR DESCRIPTION
## 🔥 Related Issues

- close #287 

## ✅ 작업 리스트

- [ ] 리뷰 페이지 퍼블리싱
- [ ] 바텀시트 퍼블리싱
- [ ] 증상은 여러개 선택 가능
- [ ] 진단은 1개만 선택 가능
- [ ] api연동(신체, 증상, 질병, 방문목적 조회)

## 🔧 작업 내용
🚨 이번주 주말내로 리뷰하시는 경우 피그마 뷰와 제 구현 뷰가 일치하지 않을 수 있습니다. 
주말이전에 뷰 확인하고 싶으신 분은 앱잼 피그마 - 마이페이지-증상 질병 수정하기 바텀시트 참고해주시면 감사하겠습니다.  

<br />

🎬 사건의 전말
원래 피그마뷰가 새로운 디자인의 바텀시트였습니다. 
리뷰 2페이지 바텀시트가 기존의 CategoryBottomSheet와 맥락이 유사한듯 하여 디자이너 선생님께 건의했고 수용해주셔서 이번주내로 피그마 뷰 수정해주신다고 합니다. (기-디-웹 합의완료, 저는 앱잼단 뷰 보고 구현했습니다.)

<br />

1페이지 바텀시트는 처음부터 직접 구현을 했었는데, 이번에는 있는 바텀시트 관련 컴포넌트 활용해서 구현했습니다.
`FilterBottomSheet`를 가장 많이 참고했습니다. 준혁님 감사합니다 덕분에 퍼블리싱 면했어요..🙏 
그대로 가져다 사용하려 했으나, 제 부분은 전역상태관리까지는 필요없고, `react-hook-form`활용해서 제출예정이라 재구성했습니다. 

<br />

## 📣 리뷰어에게 어떠신가요?
**공통컴포넌트 변동사항**
반응형으로 구현하기위해 `BottomSheet` 컴포넌트 수정했습니다.
배포 링크에서 보니까 해당 컴포넌트 활용한 바텀시트 모두 반응형 적용이 안되어 있더라구요.
수정해서 해당 컴포넌트 사용하던 부분에 지장 없는지, 잘 적용되는지 모두 확인완료했습니다. 
(마이페이지-수정관련 바텀시트입니다.)

## 📸 스크린샷 / GIF / Link
- 기능구현

https://github.com/user-attachments/assets/43294b83-7abf-4c80-bf64-10e8f657b694


- 반응형 확인

https://github.com/user-attachments/assets/473ad385-10b4-4d3c-a4be-e1c0ddbeacb0


