### PR TITLE
[Feat/Auth Provider] 전역적으로 사용할 AuthProvider 작성

### DIFF
--- a/src/api/shared/hook.ts
+++ b/src/api/shared/hook.ts
@@ -59,10 +59,11 @@ export const useInfiniteHospitalList = (initialParams: Omit<RequestBody, "cursor
 ************************************/
 export const useGetFavoriteHospital = (nickname: string) => {
   return useQuery({
-    queryKey: ["getFavoriteHosipital", nickname],
+    queryKey: ["getFavoriteHospital", nickname],
     queryFn: getMemeberFavoriteHospitals,
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 10,
+    enabled: !!nickname,
   });
 };
 
@@ -73,7 +74,7 @@ export const usePatchFavoriteHospital = () => {
     mutationFn: async (hospitalId: number) => patchMemberFavoriteHospitals(hospitalId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["getFavoriteHosipital"],
+        queryKey: ["getFavoriteHospital"],
       });
     },
   });
@@ -108,6 +109,7 @@ export const useInfiniteHospitalReview = (initialParams: UseInfiniteHospitalRevi
       // 다음 페이지를 위해 마지막 리뷰의 ID를 반환
       return cursorId;
     },
+    enabled: !!initialParams.nickname,
   });
 };
 
@@ -118,6 +120,7 @@ export const useGetMemberHospitalReviews = (nickname: string, cursorId: number |
       getMemeberHospitalReviews(nickname, cursorId, size);
     },
     staleTime: 1000 * 60 * 3,
+    enabled: !!nickname,
   });
 };
 
@@ -133,5 +136,3 @@ export const useDeleteHospitalReview = () => {
     },
   });
 };
-
-

--- a/src/api/shared/index.ts
+++ b/src/api/shared/index.ts
@@ -20,7 +20,7 @@ export const getMemeberFavoriteHospitals = async ({ queryKey }: { queryKey: [str
   const response = await get<ResponseType>(`${API_PATH.MEMBERS_HOSPITALS}`, {
     params: { nickname },
   });
-  return response.data.data;
+  return response.data.data ?? null;
 };
 
 export const patchMemberFavoriteHospitals = async (hospitalId: number) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useState } from "react";
 import "@style/global.css.ts";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "@providers/AuthProvider";
 
 // Metadata는 서버 컴포넌트에서만 사용 가능합니다.
 // 이 파일은 이제 클라이언트 컴포넌트이므로 메타데이터 정의를 제거합니다.
@@ -18,19 +19,21 @@ export default function RootLayout({
 }: {
   children: ReactNode;
 }) {
-  const [queryClient] = useState(() => new QueryClient({
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: true,
       },
     },
-  }));
+  });
 
   return (
     <html lang="ko" style={{ scrollbarWidth: "none" }}>
       <body>
         <QueryClientProvider client={queryClient}>
-          <div id="root">{children}</div>
+          <AuthProvider>
+            <div id="root">{children}</div>
+          </AuthProvider>
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </body>

--- a/src/app/mypage/_component/ContentSection/ContentSection.tsx
+++ b/src/app/mypage/_component/ContentSection/ContentSection.tsx
@@ -2,19 +2,19 @@ import React from "react";
 import * as styles from "../../_style/mypage.css";
 import MyPageContent from "../MyPageContent/MyPageContent";
 import { ActiveTabType } from "../../_hooks/useMypageState";
+import { useAuth } from "@providers/AuthProvider";
 
 interface ContentSectionProps {
-  isLogin: boolean;
   activeTab: ActiveTabType;
-  nickname: string;
 }
 
-const ContentSection = ({ isLogin, activeTab, nickname }: ContentSectionProps) => {
+const ContentSection = ({ activeTab }: ContentSectionProps) => {
+  const { isAuthenticated } = useAuth();
   return (
     <article className={styles.myPageContentWrapper}>
       <div className={styles.contentBody}>
-        {isLogin ? (
-          <MyPageContent tab={activeTab} nickname={nickname} />
+        {isAuthenticated ? (
+          <MyPageContent tab={activeTab} />
         ) : (
           <div className={styles.nothingContent}>로그인 해주세요.</div>
         )}

--- a/src/app/mypage/_component/HeaderSection/HeaderSection.tsx
+++ b/src/app/mypage/_component/HeaderSection/HeaderSection.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import * as styles from "../../_style/mypage.css";
 import HeaderNav from "@common/component/HeaderNav/HeaderNav";
 import { IcSettings } from "@asset/svg";
+import { useAuth } from "@providers/AuthProvider";
 
 interface HeaderSectionProps {
-  isLogin: boolean;
   onNavigateToSettings: () => void;
 }
 
-const HeaderSection = ({ isLogin, onNavigateToSettings }: HeaderSectionProps) => {
+const HeaderSection = ({ onNavigateToSettings }: HeaderSectionProps) => {
+  const { isAuthenticated } = useAuth();
   return (
     <span style={{ position: "fixed", top: 0, width: "100%", zIndex: 10 }}>
       <HeaderNav
@@ -16,7 +17,7 @@ const HeaderSection = ({ isLogin, onNavigateToSettings }: HeaderSectionProps) =>
         rightBtn={
           <span
             className={styles.settingWrapper({
-              isLogin: isLogin,
+              isLogin: isAuthenticated,
             })}
             onClick={onNavigateToSettings}
           >

--- a/src/app/mypage/_component/MyPageContent/MyPageContent.tsx
+++ b/src/app/mypage/_component/MyPageContent/MyPageContent.tsx
@@ -13,7 +13,6 @@ import HospitalReviewWrapper from "@shared/component/HospitalReviewWrapper";
 
 interface MyPageContentPropTypes {
   tab: ActiveTabType;
-  nickname: string;
 }
 
 export interface ApiItemTypes {
@@ -31,7 +30,7 @@ export interface ApiItemTypes {
   age: number;
 }
 
-const MyPageContent = ({ tab, nickname }: MyPageContentPropTypes) => {
+const MyPageContent = ({ tab }: MyPageContentPropTypes) => {
   const router = useRouter();
   const { data: myPosts } = useGetMyPost();
   const { data: myComments } = useGetMyComment();
@@ -39,7 +38,7 @@ const MyPageContent = ({ tab, nickname }: MyPageContentPropTypes) => {
   const renderContent = (tab: ActiveTabType) => {
     switch (tab) {
       case "review":
-        return <HospitalReviewWrapper isMypage={true} nickname={nickname} />;
+        return <HospitalReviewWrapper isMypage={true} />;
       case "post":
         if (!myPosts?.length) {
           return <div className={styles.nothingContent}>{"아직 작성한 게시글이 없어요."}</div>;

--- a/src/app/mypage/_component/ProfileSection/ProfileSection.tsx
+++ b/src/app/mypage/_component/ProfileSection/ProfileSection.tsx
@@ -5,28 +5,29 @@ import { Button } from "@common/component/Button";
 import { IcChevronRight, IcPlus } from "@asset/svg";
 import Image from "next/image";
 import AddFavoriteHospital from "../AddFavoriteHospital";
-import { Disease, MemberInfo, PetInfo } from "../../_hooks/useMypageState";
+import { Disease, MemberInfo } from "../../_hooks/useMypageState";
+import { PetInfo, useProfileSectionState } from "@app/mypage/_hooks/useProfileSectionState";
+import { useMypageMemberInfo } from "@app/mypage/_store/mypageStore";
+import { useRouter } from "next/navigation";
+import { PATH } from "@route/path";
+import { useAuth } from "@providers/AuthProvider";
 
 interface ProfileSectionProps {
-  isLogin: boolean;
-  isRegister: boolean;
-  member?: MemberInfo;
-  petInfo?: PetInfo;
-  onLogin: () => void;
   onNavigateToEditPet: () => void;
   onNavigateToRegisterPet: () => void;
 }
 
-const ProfileSection = ({
-  isLogin,
-  isRegister,
-  member,
-  petInfo,
-  onLogin,
-  onNavigateToEditPet,
-  onNavigateToRegisterPet,
-}: ProfileSectionProps) => {
-  if (!isLogin) {
+const ProfileSection = ({ onNavigateToEditPet, onNavigateToRegisterPet }: ProfileSectionProps) => {
+  const navigate = useRouter();
+  const { isAuthenticated } = useAuth();
+  const member = useMypageMemberInfo((s) => s.member);
+  const { isRegister, petInfo } = useProfileSectionState();
+
+  const onLogin = () => {
+    navigate.push(PATH.LOGIN);
+  };
+
+  if (!isAuthenticated) {
     return <UnloggedProfile onLogin={onLogin} />;
   }
 

--- a/src/app/mypage/_hooks/useProfileSectionState.ts
+++ b/src/app/mypage/_hooks/useProfileSectionState.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { Disease } from "./useMypageState";
+import { useGetPetInfo } from "@api/domain/mypage/hook";
+
+export interface PetInfo {
+  petImage?: string;
+  breed?: string;
+  petAge?: string | number;
+  diseases?: Disease[];
+}
+
+export const useProfileSectionState = () => {
+  const [isRegister, setIsRegister] = useState(true);
+  const { data: petInfo } = useGetPetInfo();
+
+  useEffect(() => {
+    if (!petInfo) setIsRegister(false);
+    else setIsRegister(true);
+  }, [petInfo]);
+
+  return {
+    petInfo,
+    isRegister,
+  };
+};

--- a/src/app/mypage/_store/mypageStore.ts
+++ b/src/app/mypage/_store/mypageStore.ts
@@ -1,0 +1,13 @@
+import { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+import { MemberInfo } from "../_hooks/useMypageState";
+
+interface myPageMemberInfoStore {
+  member: MemberInfo | undefined;
+  setMemberInfo: (member: MemberInfo) => void;
+}
+
+export const useMypageMemberInfo = create<myPageMemberInfoStore>((set) => ({
+  member: undefined,
+  setMemberInfo: (member) => set({ member }),
+}));

--- a/src/app/mypage/edit-pet/PetEdit.css.ts
+++ b/src/app/mypage/edit-pet/PetEdit.css.ts
@@ -157,6 +157,7 @@ export const favoriteHospitalInfo = style({
   alignItems: "flex-start",
   gap: "0.4rem",
   flex: "1 0 0",
+  minWidth: "18.9rem",
 });
 
 export const favoriteHospitalName = style([

--- a/src/app/mypage/edit-pet/page.tsx
+++ b/src/app/mypage/edit-pet/page.tsx
@@ -26,9 +26,11 @@ import {
   useGetSymptoms,
   usePatchPetInfo,
 } from "@api/domain/mypage/edit-pet/hook";
-import { useGetPetInfo } from "@api/domain/mypage/hook";
+import { useGetPetInfo, useGetMemberInfo } from "@api/domain/mypage/hook";
 import Docs from "../../onboarding/index/common/docs/Docs.tsx";
 import SearchHospital, { Hospital } from "@shared/component/SearchHospital/SearchHospital.tsx";
+import { useGetFavoriteHospital, usePatchFavoriteHospital } from "@api/shared/hook.ts";
+import { useMypageMemberInfo } from "../_store/mypageStore.ts";
 
 //todo: 세부 종류는 종류를 기반으로 가져와서 렌더링,
 //todo2: 종류가 달라질 경우 세부 종류 선택 off 만들기
@@ -51,6 +53,12 @@ const Page = () => {
   const [petAge, setPetAge] = useState("");
   const [bodyDiseaseIds, setBodyDiseaseIds] = useState<number[]>([]); //api 요청으로 받아온 body id들을 저장해두었다가, 다시 요청에 사용
   const [bodySymptomsIds, setBodySymptomsIds] = useState<number[]>([]); //api 요청으로 받아온 body id들을 저장해두었다가, 다시 요청에 사용
+
+  const member = useMypageMemberInfo((s) => s.member);
+  const setMemberInfo = useMypageMemberInfo((s) => s.setMemberInfo);
+
+  // member 정보를 직접 가져와서 스토어에 설정
+  const { data: memberData } = useGetMemberInfo();
 
   const {
     isOpen,
@@ -87,6 +95,13 @@ const Page = () => {
   const { data: disease } = useGetDisease(bodyDiseaseIds);
   const { data: petInfo } = useGetPetInfo();
   const { mutate: patchPetInfo } = usePatchPetInfo();
+
+  // memberData가 있으면 스토어에 설정
+  useEffect(() => {
+    if (memberData) {
+      setMemberInfo(memberData);
+    }
+  }, [memberData, setMemberInfo]);
 
   useEffect(() => {
     if (diseaseBodies?.bodies && symptomBodies?.bodies) {
@@ -226,7 +241,7 @@ const Page = () => {
   };
 
   if (!petInfo?.petId) {
-    return <div>petId 미존재</div>;
+    return null;
   }
 
   return (
@@ -312,7 +327,7 @@ const Page = () => {
           categoryData={categoryData}
           onButtonClick={() => openCategoryBottomSheet("symptom")}
         />
-        <EditFavoriteHospital />
+        <EditFavoriteHospital nickname={member?.nickname || memberData?.nickname} />
         <AnimalBottomSheet petId={petInfo.petId} />
         <CategoryBottomSheet petId={petInfo.petId} />
         <AgeBottomSheet
@@ -372,12 +387,32 @@ const EditArticle = ({ title, type, selectedChips, categoryData, onButtonClick }
   );
 };
 
-const EditFavoriteHospital = () => {
+const EditFavoriteHospital = ({ nickname }: { nickname: string | undefined }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
+  const prevSelectedHospital = useRef<Hospital | null>(null);
+
+  const { mutate } = usePatchFavoriteHospital();
+  const { data } = useGetFavoriteHospital(nickname || "");
+
   const openCategoryBottomSheet = () => {
     setIsOpen(true);
   };
+
+  const handleCloseBottomSheet = () => {
+    if (!selectedHospital?.id) {
+      setIsOpen(false);
+      return;
+    }
+
+    if (prevSelectedHospital.current?.id !== selectedHospital?.id) {
+      prevSelectedHospital.current = selectedHospital;
+      mutate(selectedHospital.id);
+    }
+
+    setIsOpen(false);
+  };
+
   const handleSelectHospital = (hospital: Hospital | null) => {
     setSelectedHospital(hospital);
   };
@@ -386,13 +421,14 @@ const EditFavoriteHospital = () => {
     <article className={styles.editArticle}>
       <span className={styles.defaultText}>즐겨찾는 병원</span>
       <Divider size="small" />
-      {selectedHospital ? (
+      {data ? (
         <div className={styles.favoriteHospitalWrapper}>
           <div className={styles.favoriteHospitalInfo}>
-            <span className={styles.favoriteHospitalName}>{selectedHospital.name}</span>
-            <span
-              className={styles.favoriteHospitalSubInfo}
-            >{`${selectedHospital.address} . 리뷰 ${selectedHospital.reviewCount}`}</span>
+            <span className={styles.favoriteHospitalName}>{data.name}</span>
+            <span className={styles.favoriteHospitalSubInfo}>
+              {`${data.address} `}
+              {/* {` . 리뷰 ${data.reviewCount}`} */}
+            </span>
           </div>
           <Button
             variant={"solidNeutral"}
@@ -416,9 +452,10 @@ const EditFavoriteHospital = () => {
 
       <SearchHospital
         active={isOpen}
-        onCloseBottomSheet={() => setIsOpen(false)}
+        onCloseBottomSheet={handleCloseBottomSheet}
         selectedHospital={selectedHospital}
         onSelectHospital={handleSelectHospital}
+        initialId={data?.id}
       />
     </article>
   );

--- a/src/app/mypage/edit-pet/page.tsx
+++ b/src/app/mypage/edit-pet/page.tsx
@@ -373,7 +373,6 @@ const EditArticle = ({ title, type, selectedChips, categoryData, onButtonClick }
 };
 
 const EditFavoriteHospital = () => {
-  //todo: api로 불러와서 정보 불러오기 + 정보 수정하기 api 연동
   const [isOpen, setIsOpen] = useState(false);
   const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
   const openCategoryBottomSheet = () => {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -16,43 +16,18 @@ import ContentSection from "./_component/ContentSection/ContentSection";
  * 각 하위 컴포넌트에 필요한 데이터와 이벤트 핸들러를 전달
  */
 const Mypage = () => {
-  // 보호된 라우트 설정
-
   // 커스텀 훅을 통한 상태 관리
-  const {
-    isLogin,
-    isRegister,
-    activeTab,
-    isLoading,
-    member,
-    petInfo,
-    isActiveTab,
-    handleTabClick,
-    navigateToSettings,
-    navigateToEditPet,
-    navigateToRegisterPet,
-    setIsLogin,
-  } = useMypageState();
-
-  // 로딩 중이거나 회원 정보가 없는 경우 렌더링하지 않음
-  if (isLoading || !member) return null;
+  const { activeTab, isActiveTab, handleTabClick, navigateToSettings, navigateToEditPet, navigateToRegisterPet } =
+    useMypageState();
 
   return (
     <div style={{ position: "relative", height: "auto" }}>
       {/* 헤더 섹션 */}
-      <HeaderSection isLogin={isLogin} onNavigateToSettings={navigateToSettings} />
+      <HeaderSection onNavigateToSettings={navigateToSettings} />
 
       {/* 프로필 섹션 */}
       <article className={styles.myProfileWrapper}>
-        <ProfileSection
-          isLogin={isLogin}
-          isRegister={isRegister}
-          member={member}
-          petInfo={petInfo}
-          onLogin={() => setIsLogin(true)}
-          onNavigateToEditPet={navigateToEditPet}
-          onNavigateToRegisterPet={navigateToRegisterPet}
-        />
+        <ProfileSection onNavigateToEditPet={navigateToEditPet} onNavigateToRegisterPet={navigateToRegisterPet} />
       </article>
 
       <Divider />
@@ -61,7 +36,7 @@ const Mypage = () => {
       <TabsSection activeTab={activeTab} isActiveTab={isActiveTab} onTabClick={handleTabClick} />
 
       {/* 컨텐츠 섹션 */}
-      <ContentSection isLogin={isLogin} activeTab={activeTab} nickname={member.nickname as string} />
+      <ContentSection activeTab={activeTab} />
 
       {/* 네비게이션 섹션 */}
       <NavSection />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,7 @@ const Index = () => {
   }
 
   useEffect(() => {
-    const user = localStorage.getItem("user");
-    if (user) router.push(PATH.MAIN);
-    else router.push(PATH.LOGIN);
+    router.push(PATH.MAIN);
   }, [router]);
 
   return <></>;

--- a/src/common/component/Button/styles.css.ts
+++ b/src/common/component/Button/styles.css.ts
@@ -18,6 +18,7 @@ export const button = recipe({
       ":focus": {
         outline: "none",
       },
+      whiteSpace: "nowrap",
     },
   ],
   variants: {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, ReactNode, Suspense } from "react";
+import { isLoggedIn } from "@api/index";
+import Loading from "@common/component/Loading/Loading";
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+// 실제 인증 상태를 관리하는 내부 컴포넌트
+const AuthManager = ({ children }: { children: ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    const initializeAuth = () => {
+      try {
+        const authStatus = isLoggedIn();
+        setIsAuthenticated(authStatus);
+      } catch (error) {
+        console.error("Auth initialization failed:", error);
+        setIsAuthenticated(false);
+      } finally {
+        setIsInitialized(true);
+      }
+    };
+
+    initializeAuth();
+  }, []);
+
+  const login = () => {
+    setIsAuthenticated(true);
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    localStorage.removeItem("user");
+  };
+
+  const value: AuthContextType = {
+    isAuthenticated,
+    login,
+    logout,
+  };
+
+  // 초기화가 완료되지 않았으면 로딩 화면 표시
+  if (!isInitialized) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100vh",
+        }}
+      >
+        <Loading height={20} />
+      </div>
+    );
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+// AuthProvider 컴포넌트 (Suspense 경계 포함)
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+  return (
+    <Suspense
+      fallback={
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100vh",
+          }}
+        >
+          <Loading height={20} />
+        </div>
+      }
+    >
+      <AuthManager>{children}</AuthManager>
+    </Suspense>
+  );
+};

--- a/src/shared/component/HospitalReviewWrapper.tsx
+++ b/src/shared/component/HospitalReviewWrapper.tsx
@@ -7,16 +7,19 @@ import { isLoggedIn } from "@api/index";
 import HospitalReview from "./HospitalReview/HospitalReview";
 import { useRouter } from "next/navigation";
 import { API_PATH } from "@api/constants/apiPath";
+import { useMypageMemberInfo } from "@app/mypage/_store/mypageStore";
 
 interface HospitalReviewWrapperProps {
   isMypage?: boolean;
-  nickname: string;
 }
 
-const HospitalReviewWrapper = ({ isMypage = false, nickname }: HospitalReviewWrapperProps) => {
+const HospitalReviewWrapper = ({ isMypage = false }: HospitalReviewWrapperProps) => {
   const [isDeleteReviewModalOpen, setIsDeleteReviewModalOpen] = useState(false);
   const [selectedReviewId, setSelectedReviewId] = useState<number | null>(null);
   const [isDeleteButtonOpen, setIsDeleteButtonOpen] = useState(false);
+
+  const member = useMypageMemberInfo((s) => s.member);
+  const nickname = member?.nickname;
 
   const router = useRouter();
 
@@ -25,7 +28,7 @@ const HospitalReviewWrapper = ({ isMypage = false, nickname }: HospitalReviewWra
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteHospitalReview({
-    nickname: nickname,
+    nickname: nickname ?? "",
     cursorId: undefined,
     size: 5,
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "node",
@@ -33,49 +29,20 @@
     "incremental": true,
     "baseUrl": "./",
     "paths": {
-      "@api/*": [
-        "src/api/*"
-      ],
-      "@asset/*": [
-        "src/asset/*"
-      ],
-      "@common/*": [
-        "src/common/*"
-      ],
-      "@page/*": [
-        "src/page/*"
-      ],
-      "@app/*": [
-        "src/app/*"
-      ],
-      "@route/*": [
-        "src/route/*"
-      ],
-      "@shared/*": [
-        "src/shared/*"
-      ],
-      "@style/*": [
-        "src/style/*"
-      ],
-      "@type/*": [
-        "src/type/*"
-      ],
-      "@store/*": [
-        "src/store/*"
-      ],
-      "@auth/*": [
-        "src/auth/*"
-      ]
+      "@api/*": ["src/api/*"],
+      "@asset/*": ["src/asset/*"],
+      "@common/*": ["src/common/*"],
+      "@page/*": ["src/page/*"],
+      "@app/*": ["src/app/*"],
+      "@route/*": ["src/route/*"],
+      "@shared/*": ["src/shared/*"],
+      "@style/*": ["src/style/*"],
+      "@type/*": ["src/type/*"],
+      "@store/*": ["src/store/*"],
+      "@auth/*": ["src/auth/*"],
+      "@providers/*": ["src/providers/*"]
     }
   },
-  "include": [
-    "./dist/types/**/*.d.ts",
-    "./next-env.d.ts",
-    ".next/types/**/*.ts",
-    "src",
-    "./dist/types/**/*.ts"
-  ],
-  "exclude": [
-    "./node_modules"
-  ]
+  "include": ["./dist/types/**/*.d.ts", "./next-env.d.ts", ".next/types/**/*.ts", "src", "./dist/types/**/*.ts"],
+  "exclude": ["./node_modules"]
 }


### PR DESCRIPTION
## ✅ 작업 리스트

- [x] 마이페이지 리팩토링 및 useAuth 적용
- [x] AuthProvider, Suspense, useAuth 작성
- [x] 기본적으로 main으로 가도록 만들어요

## 🔧 작업 내용
사용 방법에 대해 정리해놓아요.

1. 사용하고자 하는 컴포넌트에서 ` const { isAuthenticated } = useAuth();` 와 같은 방식으로 
isAuthenticated를 불러와서 로그인 여부를 결정짓는다.
2. 만약 필요하다면 `const {login, logout} = useAuth();` 를 통해 로그인, 로그아웃 함수를 사용한다. 

아래는 사용 예시에요. (로그인, 로그아웃 판별)
<img width="540" alt="image" src="https://github.com/user-attachments/assets/fc00974a-3ed6-46ae-9ca6-098282fd5f17" />


## 📣 리뷰어에게 어떠신가요?
사용방법만 익히면 되는거라, 빠르게 머지할게요!
간단하게 확인후 어프룹 부탁드립니다~!

