### PR TITLE
[Feat/#338] 비로그인 로직 작성(마이페이지, 프로필페이지 등등)

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,9 @@ import ContentSection from "./_component/ContentSection/ContentSection";
 import NavSection from "./_component/NavSection/NavSection";
 import SuspenseWrapper from "@app/SuspenseWrapper";
 import { Suspense } from "react";
+import { useRouter } from "next/navigation";
+import { PATH } from "@route/path";
+import { useAuth } from "@providers/AuthProvider";
 
 /**
  * 프로필 페이지 컴포넌트
@@ -30,9 +33,16 @@ const Profile = () => {
 const ProfileContent = () => {
   // 커스텀 훅을 통한 상태 관리
   const { query, activeTab, isActiveTab, handleTabClick, navigateBack, member, petInfo, isLoading } = useProfileState();
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  if (!isAuthenticated) {
+    alert("로그인 후에 확인할 수 있습니다.");
+    router.push(PATH.MAIN);
+  }
 
   // 쿼리 파라미터가 없거나 로딩 중이거나 데이터가 없는 경우 렌더링하지 않음
-  if (!query || isLoading || !member || !petInfo) return null;
+  if (!query || isLoading || !member || !petInfo) return;
 
   return (
     <SuspenseWrapper>
@@ -42,7 +52,7 @@ const ProfileContent = () => {
 
         {/* 프로필 섹션 */}
         <article className={styles.myProfileWrapper}>
-          <ProfileSection member={member} petInfo={petInfo}  />
+          <ProfileSection member={member} petInfo={petInfo} />
         </article>
 
         <Divider />

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -9,11 +9,18 @@ import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomS
 import useSimpleBottomSheet from "@shared/hook/useSimpleBottomSheet";
 import { PATH } from "@route/path";
 import { useLogout } from "@api/domain/setting/hook";
+import { useAuth } from "@providers/AuthProvider";
 
 export default function SettingPage() {
   const router = useRouter();
+  const { isAuthenticated } = useAuth();
   const { isOpen, openBottomSheet, closeBottomSheet } = useSimpleBottomSheet();
   const { mutate: logout } = useLogout();
+
+  if (!isAuthenticated) {
+    alert("접근할 수 없습니다.");
+    router.push(PATH.MAIN);
+  }
 
   return (
     <>
@@ -59,4 +66,4 @@ export default function SettingPage() {
       />
     </>
   );
-} 
+}

--- a/src/shared/component/HospitalReviewWrapper.tsx
+++ b/src/shared/component/HospitalReviewWrapper.tsx
@@ -5,23 +5,23 @@ import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomS
 import { useDeleteHospitalReview, useInfiniteHospitalReview } from "@api/shared/hook";
 import { isLoggedIn } from "@api/index";
 import HospitalReview from "./HospitalReview/HospitalReview";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { API_PATH } from "@api/constants/apiPath";
 import { useMypageMemberInfo } from "@app/mypage/_store/mypageStore";
 
 interface HospitalReviewWrapperProps {
   isMypage?: boolean;
+  nickname?: string;
 }
 
-const HospitalReviewWrapper = ({ isMypage = false }: HospitalReviewWrapperProps) => {
+const HospitalReviewWrapper = ({ isMypage = false, nickname: _nickname }: HospitalReviewWrapperProps) => {
+  const router = useRouter();
   const [isDeleteReviewModalOpen, setIsDeleteReviewModalOpen] = useState(false);
   const [selectedReviewId, setSelectedReviewId] = useState<number | null>(null);
   const [isDeleteButtonOpen, setIsDeleteButtonOpen] = useState(false);
 
   const member = useMypageMemberInfo((s) => s.member);
-  const nickname = member?.nickname;
-
-  const router = useRouter();
+  const nickname = isMypage ? member?.nickname : _nickname;
 
   const isBlurred = !isLoggedIn();
   const observerRef = useRef<IntersectionObserver | null>(null);


### PR DESCRIPTION
## 🔥 Related Issues

- close #338 

## ✅ 작업 리스트

- [x] 마이페이지
- [x] 프로필페이지
- [x] 세팅페이지

## 🔧 작업 내용
3가지 페이지의 비로그인 로직을 모두 적용하면서, 작업을 끝냅니다.
전에 useAuth를 만드는 PR에서 마이페이지도 어쩌다보니 조금은 같이 작업이 되어서, 
현재 PR에서는 작업이 그리 많지 않아요.

## 📣 리뷰어에게 어떠신가요?
`const {isAuthenticated} = useAuth();`
만 사용하면 되니까 금방 끝났네요. 다들 잘 이용하셨으면 좋겠어요!

