### PR TITLE
[QA][#382] 마이페이지 / 프로필페이지 / 병원검색필터 QA 반영

### DIFF
--- a/src/api/shared/hook.ts
+++ b/src/api/shared/hook.ts
@@ -36,7 +36,7 @@ export const useInfiniteHospitalList = (initialParams: Omit<RequestBody, "cursor
     initialPageParam: {},
     getNextPageParam: (lastPage) => {
       //룰은 https://www.notion.so/API-1c3c12bc8533807ca1dee16f155604d4 참고
-      const { cursorId, cursorReviewCount, hospitals } = lastPage || {};
+      const { cursorId, cursorReviewCount, hospitals } = lastPage?.data || {};
 
       // 더 이상 데이터가 없으면 undefined 반환 -> hasNextPage가 false로 설정됨
       if (!hospitals || hospitals.length === 0) {

--- a/src/app/mypage/_component/AddFavoriteHospital.tsx
+++ b/src/app/mypage/_component/AddFavoriteHospital.tsx
@@ -21,14 +21,16 @@ const AddFavoriteHospital = ({ nickname }: AddFavoriteHospitalPropTypes) => {
   };
 
   const handleCloseHospitalSearchBottomSheet = () => {
-    if (!selectedHospital?.id) return;
+    setIsHospitalSearchBottomSheetOpen(false);
+  };
 
+  const handleClickConfirm = () => {
+    if (!selectedHospital?.id) return;
     if (prevSelectedHospital.current?.id !== selectedHospital?.id) {
       prevSelectedHospital.current = selectedHospital;
       mutate(selectedHospital.id);
     }
-
-    setIsHospitalSearchBottomSheetOpen(false);
+    handleCloseHospitalSearchBottomSheet();
   };
 
   const handleSelectHospital = (hospital: Hospital | null) => {
@@ -58,6 +60,7 @@ const AddFavoriteHospital = ({ nickname }: AddFavoriteHospitalPropTypes) => {
       {/* 병원 검색 바텀시트 */}
       <SearchHospital
         active={isHospitalSearchBottomSheetOpen}
+        onConfirm={handleClickConfirm}
         onCloseBottomSheet={handleCloseHospitalSearchBottomSheet}
         selectedHospital={selectedHospital}
         onSelectHospital={handleSelectHospital}

--- a/src/app/mypage/_component/MyPageContent/MyPageContent.tsx
+++ b/src/app/mypage/_component/MyPageContent/MyPageContent.tsx
@@ -54,6 +54,7 @@ const MyPageContent = ({ tab }: MyPageContentPropTypes) => {
               commentCnt={data.commentCount}
               timeAgo={formatTime(data.createdAt as string)}
               onClick={() => router.push(`${PATH.COMMUNITY.ROOT}/${data.id}`)}
+              postImage={data.image}
             />
           </div>
         ));

--- a/src/app/mypage/_style/mypage.css.ts
+++ b/src/app/mypage/_style/mypage.css.ts
@@ -3,6 +3,18 @@ import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 import * as a from "@shared/style/atomic.css";
 
+export const mypageContainer = style([
+  a.fullWidth,
+  {
+    position: "relative",
+    height: "100vh",
+    overflow: "scroll",
+    "::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+]);
+
 /* ------------------- 프로필 섹션 스타일 ------------------- */
 export const myProfileWrapper = style([
   a.fullWidth,

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -21,7 +21,7 @@ const Mypage = () => {
     useMypageState();
 
   return (
-    <div style={{ position: "relative", height: "auto" }}>
+    <div className={styles.mypageContainer}>
       {/* 헤더 섹션 */}
       <HeaderSection onNavigateToSettings={navigateToSettings} />
 

--- a/src/app/onboarding/index/Onboarding.tsx
+++ b/src/app/onboarding/index/Onboarding.tsx
@@ -1,8 +1,13 @@
-import {useProtectedRoute} from "@route/useProtectedRoute";
+import { useProtectedRoute } from "@route/useProtectedRoute";
 import Nickname from "./component/nickname/Nickname";
 
 const Onboarding = () => {
-  useProtectedRoute();
+  const { isWillRedirect } = useProtectedRoute();
+
+  if (isWillRedirect) {
+    return null;
+  }
+
   return (
     <>
       <Nickname />

--- a/src/app/profile/_component/ProfileSection/ProfileSection.tsx
+++ b/src/app/profile/_component/ProfileSection/ProfileSection.tsx
@@ -3,7 +3,7 @@ import * as styles from "../../_style/profile.css";
 import * as favoriteHospitalStyles from "./FavoriteHospital.css";
 import Divider from "@common/component/Divider/Divider";
 import { Disease, MemberInfo, PetInfo } from "../../_hooks/useProfileState";
-import { useRouter } from "next/router";
+import { useRouter } from "next/navigation";
 import { useGetFavoriteHospital } from "@api/shared/hook";
 
 interface ProfileSectionProps {

--- a/src/app/profile/_style/profile.css.ts
+++ b/src/app/profile/_style/profile.css.ts
@@ -2,6 +2,18 @@ import { color, font, semanticColor } from "@style/styles.css";
 import { style } from "@vanilla-extract/css";
 import * as a from "./atomic.css";
 
+export const profileContainer = style([
+  a.fullWidth,
+  {
+    position: "relative",
+    height: "100vh",
+    overflow: "scroll",
+    "::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+]);
+
 /* ------------------- 프로필 섹션 스타일 ------------------- */
 export const myProfileWrapper = style([
   a.fullWidth,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -46,7 +46,7 @@ const ProfileContent = () => {
 
   return (
     <SuspenseWrapper>
-      <div style={{ position: "relative", height: "auto" }}>
+      <div className={styles.profileContainer}>
         {/* 헤더 섹션 */}
         <HeaderSection onNavigateBack={navigateBack} />
 

--- a/src/auth/RedirectKakao.tsx
+++ b/src/auth/RedirectKakao.tsx
@@ -2,10 +2,12 @@ import { API_PATH } from "@api/constants/apiPath";
 import { useNavigate } from "react-router-dom";
 import { paths } from "@type/schema";
 import Loading from "@common/component/Loading/Loading";
+import { useAuth } from "@providers/AuthProvider";
 
 const RedirectKakao = () => {
   const navigate = useNavigate();
   const code = new URL(window.location.href).searchParams.get("code"); // URL에서 인가 코드 파싱
+  const { login } = useAuth();
 
   type responseType = paths["/api/dev/members/login"]["post"]["responses"]["200"]["content"]["*/*"];
 
@@ -37,6 +39,7 @@ const RedirectKakao = () => {
         }),
       );
 
+      login();
       navigate("/onboarding");
     } catch (e) {
       console.log(e);

--- a/src/common/component/Content/Content.tsx
+++ b/src/common/component/Content/Content.tsx
@@ -74,13 +74,7 @@ const Content = ({
       </div>
       {postImage && (
         <div className={styles.postImage}>
-          <Image 
-            className={styles.postImage}
-            src={postImage} 
-            alt="Post image" 
-            width={0}
-            height={0}
-          />
+          <Image className={styles.postImage} src={postImage} alt="Post image" width={76} height={76} />
         </div>
       )}
     </div>

--- a/src/shared/component/HospitalReviewWrapper.tsx
+++ b/src/shared/component/HospitalReviewWrapper.tsx
@@ -127,7 +127,7 @@ const HospitalReviewWrapper = ({ isMypage = false, nickname: _nickname }: Hospit
             )}
           </div>
           <HospitalReview
-            handleHospitalDetailClick={() => handleHospitalDetailClick(review.id as number)}
+            handleHospitalDetailClick={() => handleHospitalDetailClick(review.hospitalId as number)}
             reviewData={review}
             isBlurred={isBlurred}
             isNoProfile={true}

--- a/src/shared/component/SearchHospital/SearchHospital.tsx
+++ b/src/shared/component/SearchHospital/SearchHospital.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { useDebounce } from "@shared/hook/useDebounce";
 import { useInfiniteHospitalList } from "@api/shared/hook";
 import { components } from "@type/schema";
+import { usePathname } from "next/navigation";
 
 type HospitalResponse = components["schemas"]["HospitalResponse"];
 
@@ -25,8 +26,9 @@ interface SearchHospitalProps {
   onCloseBottomSheet: () => void;
   selectedHospital: Hospital | null;
   onSelectHospital: (hospital: Hospital | null) => void;
-  locationId?: number; // 지역 ID (옵션)
-  locationType?: "CITY" | "DISTRICT"; // 지역 타입 (옵션)
+  onConfirm?: () => void;
+  locationId?: number; // 지역 ID (옵션) - 병원 리뷰에서는 보내면 안됨
+  locationType?: "CITY" | "DISTRICT"; // 지역 타입 (옵션) - 병원 리뷰에서는 보내면 안됨
 }
 
 const SearchHospital = (props: SearchHospitalProps) => {
@@ -36,9 +38,13 @@ const SearchHospital = (props: SearchHospitalProps) => {
     onCloseBottomSheet,
     selectedHospital,
     onSelectHospital,
+    onConfirm,
     locationId = 1,
     locationType = "CITY",
   } = props;
+
+  const pathName = usePathname();
+  const isReview = pathName?.includes("review");
 
   // 스크롤 방지
   useEffect(() => {
@@ -70,8 +76,8 @@ const SearchHospital = (props: SearchHospitalProps) => {
   // useInfiniteQuery를 사용하여 병원 목록 가져오기
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } = useInfiniteHospitalList(
     {
-      locationId,
-      locationType,
+      locationId: isReview ? undefined : locationId,
+      locationType: isReview ? undefined : locationType,
       keyword: debouncedSearchWord || undefined,
       size: 10,
       sortBy: debouncedSearchWord ? undefined : "REVIEW",
@@ -194,7 +200,7 @@ const SearchHospital = (props: SearchHospitalProps) => {
             size="large"
             variant="solidPrimary"
             disabled={!selectedHospital}
-            onClick={onCloseBottomSheet}
+            onClick={onConfirm ?? onCloseBottomSheet}
           />
           <Button label="취소하기" size="large" variant="solidNeutral" disabled={false} onClick={handleCancelSearch} />
         </div>


### PR DESCRIPTION
## 🔥 Related Issues

- close #382 

## ✅ 작업 리스트

- [x] 로그인 직후 회원가입 페이지 잠깐 들리는 문제 수정
- [x] 병원 검색 취소 버튼 동작하도록 수정 && 병원 리뷰에서의 req body 내용 수정
- [x] 병원 검색 바텀시트 무한스크롤 동작하도록 수정(잘못 참조로 인한 동작 안함 버그)
- [x] 로그인 상태 바로 반영되도록 login() 함수 추가
- [x] 프로필페이지 안 뜨던 버그 수정(router/navigation으로 사용)
- [x] 병원 디테일 리다이렉트 되도록 수정
- [x] 나의 게시글 이미지 뜨도록 기능 추가
- [x] 페이지네이션 맨 위로 올라가지 않도록 수정 

## 🔧 작업 내용
단순 QA 목록 뿐만 아니라, 작업 중 발견된 버그들도 같이 수정했어요. 
커밋은 QA 단위로 나눠두어 좀 많아보이지만, 작업양 자체는 그리 많진 않아요. 간단하게만 확인하고 어프룹 부탁드려요~!

## 📣 리뷰어에게 어떠신가요?
참고하시면 좋을 것 같아 간단히 정리해둡니다.

DOM이 수정되면 스크롤 상태를 잃게 돼요.  (예를 들어, DOM 요소의 height가 변하면 DOM이 변하게 돼요.)
페이지네이션시 맨 위로 스크롤 되게 했던 것도, 기존에는 무한 스크롤을 고려하지 않고 height를 auto로 해두었기 때문이에요.
따라서 height를 고정해두고 overflow: scroll로 요소를 다루어 무한스크롤에도 스크롤의 상태를 잃지 않도록 방지했어요. 


## 📸 스크린샷 / GIF / Link
