### PR TITLE
[QA/#389] api 중복요청 방지작업 (동물등록, 리뷰등록, 리뷰동의)

### DIFF
--- a/src/app/api/review/agree/hook.ts
+++ b/src/app/api/review/agree/hook.ts
@@ -1,13 +1,29 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { patchAgreeReview } from "@app/api/review/agree";
+import { getReviewAgreementStatus } from "./index";
 
+// 리뷰 동의 PATCH API
 export const useAgreeReviewMutation = () => {
   return useMutation({
     mutationFn: patchAgreeReview,
     onError: (error) => {
       console.error("동의 API 호출 실패:", error);
+    },
+  });
+};
+
+// 리뷰 동의 여부 조회 GET API
+export const REVIEW_AGREE_QUERY_KEY = {
+  REVIEW_AGREE_QUERY_KEY: () => ["reviewAgreement"],
+};
+
+export const useGetReviewAgreementStatus = () => {
+  return useQuery({
+    queryKey: REVIEW_AGREE_QUERY_KEY.REVIEW_AGREE_QUERY_KEY(),
+    queryFn: () => {
+      return getReviewAgreementStatus();
     },
   });
 };

--- a/src/app/api/review/agree/index.ts
+++ b/src/app/api/review/agree/index.ts
@@ -1,10 +1,11 @@
 import { API_PATH } from "@api/constants/apiPath";
-import { getAccessToken } from "@api/index";
-import { patch } from "@api/index";
+import { paths } from "@type/schema";
+import { patch, get, getAccessToken } from "@api/index";
 
+const token = getAccessToken();
+
+// 리뷰 동의 PATCH API
 export const patchAgreeReview = async () => {
-  const token = getAccessToken();
-
   const response = await patch(
     API_PATH.MEMBERS_REVIEWS_AGREE,
     {},
@@ -16,4 +17,16 @@ export const patchAgreeReview = async () => {
   );
 
   return response.data;
+};
+
+// 리뷰 동의 여부 조회 GET API
+export type agreeGetResponse = paths["/api/dev/members/reviews/agree"]["get"]["responses"]["200"]["content"]["*/*"];
+
+export const getReviewAgreementStatus = async () => {
+  const { data } = await get<agreeGetResponse>(API_PATH.MEMBERS_REVIEWS_AGREE, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return data.data;
 };

--- a/src/app/register-pet/index/RegisterPet.tsx
+++ b/src/app/register-pet/index/RegisterPet.tsx
@@ -105,6 +105,7 @@ const RegisterPet = () => {
             handleSubmit={handleSubmit}
             currentStep={currentStep}
             setCurrentStep={setCurrentStep}
+            isPending={isPending}
           />
         );
 

--- a/src/app/register-pet/index/component/petHealth/PetHealth.tsx
+++ b/src/app/register-pet/index/component/petHealth/PetHealth.tsx
@@ -40,8 +40,6 @@ const PetHealth = ({
   // 증상 대분류, 소분류
   const [selectedSymptomBody, setSelectedSymBodyParts] = useState<number[]>([]);
   const [selectedSymptom, setSelectedSymptoms] = useState<number[]>([]);
-  // 반려동물 등록 중복요청 방지
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 질병 선택 부위 (최대 2개 선택 가능???)
   const handleBodyPartSelection = (bodyPartId: number) => {
@@ -139,20 +137,12 @@ const PetHealth = ({
   // 최종 폼 제출
   const router = useRouter();
   const handleGoComplete = () => {
-    if (isSubmitting) return;
     if (selectedSymptom.length === 0) return;
 
-    setIsSubmitting(true);
-
-    try {
-      updatePetData("symptomIds", selectedSymptom, () => {
-        handleSubmit();
-        router.push(PATH.REGISTER_PET.COMPLETE);
-      });
-    } finally {
-      // 제출 실패한 경우 재활성화
-      setIsSubmitting(false);
-    }
+    updatePetData("symptomIds", selectedSymptom, () => {
+      handleSubmit();
+      router.push(PATH.REGISTER_PET.COMPLETE);
+    });
   };
 
   const { data: diseaseData } = useBodiesGet("disease");
@@ -247,7 +237,7 @@ const PetHealth = ({
               label="다음"
               size="large"
               variant="solidPrimary"
-              disabled={selectedSymptom.length === 0 || isSubmitting}
+              disabled={selectedSymptom.length === 0}
               onClick={handleGoComplete} // 증상 선택 후 폼 제출
             />
           </div>

--- a/src/app/register-pet/index/component/petHealth/PetHealth.tsx
+++ b/src/app/register-pet/index/component/petHealth/PetHealth.tsx
@@ -1,13 +1,13 @@
 import * as styles from "./PetHealth.css";
-import {useState} from "react";
-import {useRouter} from "next/navigation";
-import {PATH} from "@route/path";
-import {Button} from "@common/component/Button";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { PATH } from "@route/path";
+import { Button } from "@common/component/Button";
 
-import {useBodiesGet} from "@api/domain/register-pet/bodies/hook";
-import {useDiseaseGet} from "@api/domain/register-pet/disease/hook";
-import {useSymptomGet} from "@api/domain/register-pet/symptom/hook";
-import {PetData} from "../../RegisterPet.tsx";
+import { useBodiesGet } from "@api/domain/register-pet/bodies/hook";
+import { useDiseaseGet } from "@api/domain/register-pet/disease/hook";
+import { useSymptomGet } from "@api/domain/register-pet/symptom/hook";
+import { PetData } from "../../RegisterPet.tsx";
 import Step1 from "./disease/Step1.tsx";
 import Step2 from "./disease/Step2.tsx";
 import SymStep1 from "./symptom/SymStep1.tsx";
@@ -40,6 +40,8 @@ const PetHealth = ({
   // 증상 대분류, 소분류
   const [selectedSymptomBody, setSelectedSymBodyParts] = useState<number[]>([]);
   const [selectedSymptom, setSelectedSymptoms] = useState<number[]>([]);
+  // 반려동물 등록 중복요청 방지
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 질병 선택 부위 (최대 2개 선택 가능???)
   const handleBodyPartSelection = (bodyPartId: number) => {
@@ -137,13 +139,19 @@ const PetHealth = ({
   // 최종 폼 제출
   const router = useRouter();
   const handleGoComplete = () => {
-    if (selectedSymptom.length > 0) {
+    if (isSubmitting) return;
+    if (selectedSymptom.length === 0) return;
+
+    setIsSubmitting(true);
+
+    try {
       updatePetData("symptomIds", selectedSymptom, () => {
         handleSubmit();
         router.push(PATH.REGISTER_PET.COMPLETE);
       });
-    } else {
-      return;
+    } finally {
+      // 제출 실패한 경우 재활성화
+      setIsSubmitting(false);
     }
   };
 
@@ -239,7 +247,7 @@ const PetHealth = ({
               label="다음"
               size="large"
               variant="solidPrimary"
-              disabled={selectedSymptom.length === 0}
+              disabled={selectedSymptom.length === 0 || isSubmitting}
               onClick={handleGoComplete} // 증상 선택 후 폼 제출
             />
           </div>

--- a/src/app/register-pet/index/component/petHealth/PetHealth.tsx
+++ b/src/app/register-pet/index/component/petHealth/PetHealth.tsx
@@ -24,6 +24,7 @@ interface PetHealthPropTypes {
   setCurrentStep: React.Dispatch<React.SetStateAction<number | null>>;
   isSkipDisease: boolean | null;
   handleSubmit: () => void;
+  isPending: boolean;
 }
 
 const PetHealth = ({
@@ -33,6 +34,7 @@ const PetHealth = ({
   updatePetData,
   handleSubmit,
   isSkipDisease,
+  isPending,
 }: PetHealthPropTypes) => {
   // 질병 대분류, 소분류
   const [selectedDiseaseBody, setSelectedDiseaseBody] = useState<number[]>([]);
@@ -137,6 +139,7 @@ const PetHealth = ({
   // 최종 폼 제출
   const router = useRouter();
   const handleGoComplete = () => {
+    if (isPending) return;
     if (selectedSymptom.length === 0) return;
 
     updatePetData("symptomIds", selectedSymptom, () => {
@@ -230,14 +233,14 @@ const PetHealth = ({
               label="이전으로"
               size="large"
               variant="solidNeutral"
-              disabled={false}
+              disabled={isPending}
               onClick={handleBackSymptom1}
             />
             <Button
               label="다음"
               size="large"
               variant="solidPrimary"
-              disabled={selectedSymptom.length === 0}
+              disabled={selectedSymptom.length === 0 || isPending}
               onClick={handleGoComplete} // 증상 선택 후 폼 제출
             />
           </div>

--- a/src/app/register-pet/index/component/petName/PetName.tsx
+++ b/src/app/register-pet/index/component/petName/PetName.tsx
@@ -31,16 +31,6 @@ const PetName = ({ setStep, updatePetData }: PetNameProps) => {
 
   const isPetRegistered = useIsPetRegistered();
 
-  // useEffect(() => {
-  //   // 등록된 반려동물이 있는 경우 진입 불가
-  //   if (isPetRegistered) {
-  //     console.log("isPetRegistered 값:", isPetRegistered);
-  //     alert("이미 반려동물이 등록되어 있습니다.");
-
-  //     window.history.go(-1);
-  //   }
-  // }, [isPetRegistered]);
-
   useEffect(() => {
     if (isPetRegistered) {
       alert("이미 반려동물이 등록되어 있습니다.");

--- a/src/app/register-pet/index/component/petName/PetName.tsx
+++ b/src/app/register-pet/index/component/petName/PetName.tsx
@@ -1,17 +1,18 @@
-import React, {ChangeEvent, useState} from "react";
-import {useRouter} from "next/navigation";
+import React, { ChangeEvent, useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import * as styles from "./PetName.css";
 
-import {TextField} from "@common/component/TextField";
-import {Button} from "@common/component/Button";
-import {validatePetName} from "@shared/util/validatePetName";
+import { TextField } from "@common/component/TextField";
+import { Button } from "@common/component/Button";
+import { validatePetName } from "@shared/util/validatePetName";
 import petNameBori from "@asset/image/petNameBori.png";
-import {PATH} from "@route/path";
+import { PATH } from "@route/path";
 import Image from "next/image";
-import {PetData} from "../../RegisterPet.tsx";
-import {ONBOARDING_GUIDE} from "../../../../onboarding/index/constant/onboardingGuide.ts";
+import { PetData } from "../../RegisterPet.tsx";
+import { ONBOARDING_GUIDE } from "../../../../onboarding/index/constant/onboardingGuide.ts";
 import Title from "../../../../onboarding/index/common/title/Title.tsx";
 import Docs from "../../../../onboarding/index/common/docs/Docs.tsx";
+import { useIsPetRegistered } from "@common/hook/useIsPetRegistered.ts";
 
 interface PetNameProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -27,6 +28,28 @@ const PetName = ({ setStep, updatePetData }: PetNameProps) => {
 
   const validationMessages = petName ? validatePetName(petName) : [];
   const isValid = petName && validationMessages.length === 0;
+
+  const isPetRegistered = useIsPetRegistered();
+
+  // useEffect(() => {
+  //   // 등록된 반려동물이 있는 경우 진입 불가
+  //   if (isPetRegistered) {
+  //     console.log("isPetRegistered 값:", isPetRegistered);
+  //     alert("이미 반려동물이 등록되어 있습니다.");
+
+  //     window.history.go(-1);
+  //   }
+  // }, [isPetRegistered]);
+
+  useEffect(() => {
+    if (isPetRegistered) {
+      alert("이미 반려동물이 등록되어 있습니다.");
+      window.history.go(-1);
+    }
+  }, [isPetRegistered]);
+
+  // 등록된 경우엔 화면 자체를 보여주지 않음
+  if (isPetRegistered) return null;
 
   // 뒤로 가기
   const router = useRouter();

--- a/src/app/review/agree/page.tsx
+++ b/src/app/review/agree/page.tsx
@@ -9,11 +9,12 @@ import Divider from "@common/component/Divider/Divider";
 import { Button } from "@common/component/Button";
 import * as style from "./style.css";
 import { IcCheckbox } from "@asset/svg";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { TITLE, CHECKBOX_TEXTS } from "@app/review/agree/constant";
 import { useAgreeReviewMutation } from "@app/api/review/agree/hook";
 import { useRouter } from "next/navigation";
 import { PATH } from "@route/path";
+import { useGetReviewAgreementStatus } from "@app/api/review/agree/hook";
 
 const page = () => {
   const CHECKBOX_COUNT = CHECKBOX_TEXTS.length;
@@ -21,6 +22,15 @@ const page = () => {
 
   const mutation = useAgreeReviewMutation();
   const router = useRouter();
+
+  const isReviewAgree = useGetReviewAgreementStatus();
+
+  // url 입력해서 들어오는 경우 방지
+  useEffect(() => {
+    if (isReviewAgree) {
+      router.push(PATH.REVIEW.WRITE);
+    }
+  }, [isReviewAgree]);
 
   const handleClickBtn = () => {
     mutation.mutate(undefined, {

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -19,6 +19,7 @@ interface Step4Props {
 
 const Step4 = ({ onPrev, onNext }: Step4Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const searchParams = useSearchParams();
   const rawHospitalId = searchParams?.get("hospitalId");
   const hospitalId = rawHospitalId ? Number(rawHospitalId) : undefined;
@@ -35,6 +36,12 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
   const { handleSubmit } = useFormContext<ReviewFormData>();
 
   const onValid = (data: ReviewFormData) => {
+    if (isSubmitting) {
+      console.log("[중단] 이미 제출 중입니다.");
+      return;
+    }
+
+    setIsSubmitting(true); // 제출 시작
     submitReview(
       {
         ...data,
@@ -68,9 +75,11 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
             );
 
             onNext();
+            setIsSubmitting(false); // 제출 완료 후 상태 해제
           } catch (uploadErr) {
             console.error("이미지 업로드 실패", uploadErr);
             alert("이미지 업로드에 실패했습니다.");
+            setIsSubmitting(false); // 실패 시 해제
           }
         },
 
@@ -80,6 +89,7 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
           } else {
             alert("리뷰 작성에 실패했습니다.");
           }
+          setIsSubmitting(false); // 실패 시 해제
         },
       },
     );

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -37,7 +37,6 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
 
   const onValid = (data: ReviewFormData) => {
     if (isSubmitting) {
-      console.log("[중단] 이미 제출 중입니다.");
       return;
     }
 

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -31,7 +31,7 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
     throw new Error("유효하지 않은 병원입니다.");
   }
 
-  const { mutate: submitReview } = useReviewPost(hospitalId);
+  const { mutate: submitReview, isPending } = useReviewPost(hospitalId);
   const { handleSubmit } = useFormContext<ReviewFormData>();
   const { getValues } = useFormContext<ReviewFormWithUIData>();
 
@@ -106,6 +106,11 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
     window.history.go(-2);
   };
 
+  const handleSubmitReview = () => {
+    if (isPending) return; // 이미 요청 중이면 더블 클릭 방지
+    handleSubmit(onValid)();
+  };
+
   return (
     <div className={styles.wrapper}>
       {/* 상단 리뷰 영역 */}
@@ -127,8 +132,8 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
 
       {/* 하단 버튼 영역 */}
       <section className={styles.btnLayout}>
-        <Button label="이전으로" size="large" variant="solidNeutral" onClick={onPrev} />
-        <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} />
+        <Button label="이전으로" size="large" variant="solidNeutral" onClick={onPrev} disabled={isPending} />
+        <Button label="다음으로" size="large" variant="solidPrimary" onClick={handleNext} disabled={isPending} />
       </section>
 
       <SimpleBottomSheet
@@ -138,7 +143,7 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
         isOpen={isBottomSheetOpen}
         handleClose={handleCloseBottomSheet}
         leftOnClick={handleCloseBottomSheet}
-        rightOnClick={handleSubmit(onValid)}
+        rightOnClick={handleSubmitReview}
       />
     </div>
   );


### PR DESCRIPTION
## 🔥 Related Issues

- close #i389

## ✅ 작업 리스트

- [x] 반려동물 등록 버튼 더블클릭 방지
- [x] 리뷰 작성 완료 버튼 더블클릭 방지
- [x] 리뷰 동의 여부 조회 api 연동
- [x] 반려동물 등록 페이지 로드시, 반려동물이 등록되어 있는 유저라면 이전 페이지로 이동
- [x] 리뷰 동의 페이지 로드시, 이미 리뷰 동의를 한 유저라면 바로 리뷰 작성 페이지로 이동

## 🔧 작업 내용 및 📣 리뷰어에게
 **전체적으로 api 중복 요청을 방지하는 작업을 했습니다.**
1️⃣  반려동물 등록, 리뷰 작성 완료 더블클릭 방지 
: 구현도 하고 검증 콘솔도 작성해 봤는데, 페이지 넘어가기 전에 더블 클릭을 하는게 어렵더라구요,, 별도의 확인 영상은 없습니다..

2️⃣ 리뷰 동의 여부 조회 api 연동
: 죄송합니다.. 리뷰 동의에 대한 개념을 잘못 이해해서 api 하나가 누락되었더라구요.
저는 매 리뷰마다 리뷰 동의를 해야한다고 생각했는데, 회원가입 후 리뷰 동의는 딱 1번만 받는다고 합니다.
따라서 리뷰 동의를 한 적이 있다면 별도의 리뷰 페이지 없이 바로 리뷰 작성으로 넘어가도록 구현했습니다.

3️⃣ url 직접입력시 대응
: 위 두가지 모두 버튼을 클릭해 넘어가는 부분 말고도 url을 직접 입력하고 들어가는 경우도 고려해서 "반려동물 등록", "리뷰 동의 여부조회 페이지"의 경우에는 handle함수 외에도 페이지 로드 시 이미 반려동물이 등록 되어있다면, 리뷰 동의 처리가 되어 있다면 진입하지 못하거나 다음페이지로 넘어가도록 구현해 두었습니다. 

## 📸 스크린샷 / GIF / Link
- 반려동물 등록되어 있다면, 반려동물 등록페이지 진입 금지

https://github.com/user-attachments/assets/7c8d7d2a-21dc-422f-8335-6da05ecbfb41

- 리뷰를 동의한 유저가 리뷰 동의페이지

https://github.com/user-attachments/assets/f8807de8-26c6-4f60-987f-bf62232ae0ee

로 강제 진입시 이전으로 이동


- 리뷰를 동의한 유저가 병원 리뷰 탭 플로팅 버튼(리뷰작성 버튼)클릭 시 리뷰 동의페이지가 아닌 리뷰 작성 페이지로 이동

https://github.com/user-attachments/assets/317517cd-e18f-4710-a4c4-edfd49144d5b


