### PR TITLE
[QA/#397]review write qa 

### DIFF
--- a/src/app/review/complete/page.tsx
+++ b/src/app/review/complete/page.tsx
@@ -4,12 +4,16 @@ import dynamic from "next/dynamic";
 import * as styles from "./style.css";
 import registerPet from "@asset/lottie/registerPet.json";
 import { Button } from "@common/component/Button";
+import { useRouter } from "next/navigation";
+import { PATH } from "@route/path";
 
 const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
 
 const page = () => {
+  const router = useRouter();
+
   const handleGoHospitalDetail = () => {
-    window.history.go(-3);
+    router.push(PATH.REVIEW.ROOT);
   };
 
   return (

--- a/src/app/review/write/_component/DirectMyPetInfo.tsx
+++ b/src/app/review/write/_component/DirectMyPetInfo.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useFormContext, Controller, useWatch } from "react-hook-form";
 import * as styles from "./DirectMyPetInfo.style.css";
-import { ReviewFormData } from "../page";
+import { ReviewFormData, ReviewFormWithUIData } from "../page";
 import { TextField } from "@common/component/TextField/index";
 import DropDown from "@app/register-pet/index/common/dropDown/DropDown";
 import { GENDER, PET_TYPES } from "../constant";
@@ -12,21 +12,14 @@ type PetField = keyof ReviewFormData;
 type FocusableField = keyof ReviewFormData | "petType";
 
 interface DirectMyPetInfoProps {
-  petType: string;
-  setPetType: (value: string) => void;
   isBreedInputTouched: boolean;
   setIsBreedInputTouched: (value: boolean) => void;
 }
 
-const DirectMyPetInfo = ({
-  petType,
-  setPetType,
-  isBreedInputTouched,
-  setIsBreedInputTouched,
-}: DirectMyPetInfoProps) => {
+const DirectMyPetInfo = ({ isBreedInputTouched, setIsBreedInputTouched }: DirectMyPetInfoProps) => {
   // 내 동물정보 가져오고 직접 입력하기로 동물 종류 수정하는 경우
   const watchedBreedId = useWatch({ name: "breedId" });
-  const { control, watch, setValue } = useFormContext<ReviewFormData>();
+  const { control, watch, setValue } = useFormContext<ReviewFormWithUIData>();
 
   // 종, 성별 드롭다운
   const [activeDropDown, setActiveDropDown] = useState<"petType" | keyof ReviewFormData | null>(null);
@@ -34,6 +27,8 @@ const DirectMyPetInfo = ({
   const [focusedField, setFocusedField] = useState<FocusableField | null>(null);
   // 드롭다운 필터링용 검색 입력값 (breedId는 리뷰 제출용)
   const [breedInput, setBreedInput] = useState("");
+
+  const petType = watch("petType");
 
   const handleDropDownClick = (field: PetField, value: string | number) => {
     setValue(field, value);
@@ -93,7 +88,7 @@ const DirectMyPetInfo = ({
               items={PET_TYPES}
               onClickItem={(name) => {
                 // 리뷰 제출 항목이 아니므로 handleDropDownClick함수 사용 불가
-                setPetType(name);
+                setValue("petType", name);
                 setActiveDropDown(null);
               }}
               size="half"

--- a/src/app/review/write/_component/DirectMyPetInfo.tsx
+++ b/src/app/review/write/_component/DirectMyPetInfo.tsx
@@ -73,7 +73,6 @@ const DirectMyPetInfo = ({
         {/* 1-3-1. 종 */}
         <div className={styles.halfTextField}>
           <span>종</span>
-          {/* tavian */}
           <TextField
             value={petType}
             onClick={() => setActiveDropDown((prev) => (prev === "petType" ? null : "petType"))}
@@ -104,7 +103,6 @@ const DirectMyPetInfo = ({
             control={control}
             render={({ field }) => (
               <>
-                {/* tavian */}
                 <TextField
                   value={field.value === "F" ? "암컷" : field.value === "M" ? "수컷" : ""}
                   onClick={() => setActiveDropDown((prev) => (prev === "gender" ? null : "gender"))}

--- a/src/app/review/write/_component/DirectMyPetInfo.tsx
+++ b/src/app/review/write/_component/DirectMyPetInfo.tsx
@@ -59,10 +59,11 @@ const DirectMyPetInfo = ({
   };
 
   // 종류 조회 api 연동시 종 정보를 보내야함
-  const breedId = Number(watch("breedId"));
   const inferredPetId = useMemo(() => {
-    return breedId > 0 ? (breedId < 230 ? 2 : 1) : -1;
-  }, [breedId]);
+    if (petType === "고양이") return 1;
+    if (petType === "강아지") return 2;
+    return -1;
+  }, [petType]);
 
   // api
   const { data: breedIdData } = usePetIdGet(inferredPetId ?? 2);
@@ -75,7 +76,12 @@ const DirectMyPetInfo = ({
           <span>종</span>
           <TextField
             value={petType}
-            onClick={() => setActiveDropDown((prev) => (prev === "petType" ? null : "petType"))}
+            onClick={() => {
+              setActiveDropDown((prev) => (prev === "petType" ? null : "petType"));
+              setValue("breedId", -1); // 종 선택 시 breedId 초기화 (내 동물 정보에서 불러오기 먼저 클릭한 경우 초기화하기 위함)
+              setBreedInput(""); // 입력값도 초기화
+              setIsBreedInputTouched(false); // 입력 상태도 초기화
+            }}
             placeholder="종 선택하기"
             isDelete={false}
             state={getState("petType", petType)}

--- a/src/app/review/write/_component/DirectMyPetInfo.tsx
+++ b/src/app/review/write/_component/DirectMyPetInfo.tsx
@@ -48,6 +48,7 @@ const DirectMyPetInfo = ({
     const formatted =
       trimmedInt === "" && input.startsWith(".") ? `0.${decimal}` : `${trimmedInt}${rest.length ? `.${decimal}` : ""}`;
     onChange(formatted);
+    setValue("weight", formatted === "" ? -1 : Number(formatted));
   };
 
   // 텍스트 필드 분기 결정

--- a/src/app/review/write/_component/ReviewHospital.tsx
+++ b/src/app/review/write/_component/ReviewHospital.tsx
@@ -4,14 +4,16 @@ import * as styles from "./ReviewHospital.style.css";
 import { IcSearch } from "@asset/svg/index";
 import nicknameCoco from "@asset/image/nicknameCoco.png";
 import Image from "next/image";
-import { Hospital } from "@shared/component/SearchHospital/SearchHospital";
-
+import { useFormContext } from "react-hook-form";
+import { ReviewFormWithUIData } from "../page";
 interface ReviewHospitalProps {
-  selectedHospital: Hospital | null;
   handleOpenSearchHospital: () => void;
 }
 
-const ReviewHospital = ({ selectedHospital, handleOpenSearchHospital }: ReviewHospitalProps) => {
+const ReviewHospital = ({ handleOpenSearchHospital }: ReviewHospitalProps) => {
+  const { watch } = useFormContext<ReviewFormWithUIData>();
+  const selectedHospital = watch("selectedHospital");
+
   return (
     <>
       {/* 1-1. 병원 검색 */}

--- a/src/app/review/write/_component/ReviewPetInfo.tsx
+++ b/src/app/review/write/_component/ReviewPetInfo.tsx
@@ -16,8 +16,6 @@ const ReviewPetInfo = () => {
   // 토스트 리렌더링
   const [toastKey, setToastKey] = useState(0);
   const [showToast, setShowToast] = useState(false);
-  // 종은 리뷰 제출 항목이 아니므로 리액트 훅폼 상태에서 분리
-  const [petType, setPetType] = useState("");
   // 내 동물정보 가져오기 클릭 후 내 정보 해지 후 직접 입력하기 위한 상태
   const [isBreedInputTouched, setIsBreedInputTouched] = useState(false);
 
@@ -47,9 +45,12 @@ const ReviewPetInfo = () => {
               setValue("gender", petInfo?.petGender ?? "F");
               // 종은 리뷰 제출 항목이 아님. 직접입력하기의 활성화 상태를 맞추기위해 추가
               if (typeof petInfo?.breedId === "number") {
-                setPetType(petInfo.breedId > 0 ? (petInfo.breedId < PET_TYPE_STANDARD ? "강아지" : "고양이") : "");
+                setValue(
+                  "petType",
+                  petInfo.breedId > 0 ? (petInfo.breedId < PET_TYPE_STANDARD ? "강아지" : "고양이") : "",
+                );
               } else {
-                setPetType("");
+                setValue("petType", "");
               }
               setIsBreedInputTouched(false); // 다시 selectedBreedName을 믿어도 되는 상태
             } else {
@@ -93,8 +94,6 @@ const ReviewPetInfo = () => {
           </span>
           {selectedPetInfo === "manual" && (
             <DirectMyPetInfo
-              petType={petType}
-              setPetType={setPetType}
               isBreedInputTouched={isBreedInputTouched}
               setIsBreedInputTouched={setIsBreedInputTouched}
             />

--- a/src/app/review/write/_component/ReviewPetInfo.tsx
+++ b/src/app/review/write/_component/ReviewPetInfo.tsx
@@ -2,21 +2,16 @@ import { IcRightArror, IcChevronRight2 } from "@asset/svg/index";
 import { color } from "@style/styles.css";
 import * as styles from "./ReviewPetInfo.style.css";
 import DirectMyPetInfo from "./DirectMyPetInfo";
-import { PetInfoType } from "@app/review/write/_section/Step1";
 import { useGetPetInfo } from "@api/domain/mypage/hook";
 import { useFormContext } from "react-hook-form";
-import { ReviewFormData } from "@app/review/write/page";
+import { ReviewFormWithUIData } from "@app/review/write/page";
 import { useState } from "react";
 import { Toast } from "@common/component/Toast/Toast";
 import { PET_TYPE_STANDARD } from "../constant";
 
-interface ReviewPetInfoProps {
-  selectedPetInfo: PetInfoType | null;
-  onSelectPetInfo: (type: PetInfoType) => void;
-}
-
-const ReviewPetInfo = ({ selectedPetInfo, onSelectPetInfo }: ReviewPetInfoProps) => {
-  const { setValue } = useFormContext<ReviewFormData>();
+const ReviewPetInfo = () => {
+  const { watch, setValue } = useFormContext<ReviewFormWithUIData>();
+  const selectedPetInfo = watch("selectedPetInfoType");
   const { data: petInfo } = useGetPetInfo();
   // 토스트 리렌더링
   const [toastKey, setToastKey] = useState(0);
@@ -25,6 +20,11 @@ const ReviewPetInfo = ({ selectedPetInfo, onSelectPetInfo }: ReviewPetInfoProps)
   const [petType, setPetType] = useState("");
   // 내 동물정보 가져오기 클릭 후 내 정보 해지 후 직접 입력하기 위한 상태
   const [isBreedInputTouched, setIsBreedInputTouched] = useState(false);
+
+  const handleSelectPetInfo = (type: "myPet" | "manual") => {
+    const nextValue = selectedPetInfo === type ? null : type;
+    setValue("selectedPetInfoType", nextValue);
+  };
 
   return (
     <>
@@ -41,7 +41,7 @@ const ReviewPetInfo = ({ selectedPetInfo, onSelectPetInfo }: ReviewPetInfoProps)
             selected: selectedPetInfo === "myPet" && !!petInfo,
           })}
           onClick={() => {
-            onSelectPetInfo("myPet");
+            handleSelectPetInfo("myPet");
             if (petInfo) {
               setValue("breedId", petInfo?.breedId ?? -1);
               setValue("gender", petInfo?.petGender ?? "F");
@@ -84,7 +84,7 @@ const ReviewPetInfo = ({ selectedPetInfo, onSelectPetInfo }: ReviewPetInfoProps)
             petInfoType: "manual",
           })}
         >
-          <span className={styles.buttonText} onClick={() => onSelectPetInfo("manual")}>
+          <span className={styles.buttonText} onClick={() => handleSelectPetInfo("manual")}>
             직접 입력하기
             <IcChevronRight2
               className={styles.rotateIcon({ selected: selectedPetInfo === "manual" })}

--- a/src/app/review/write/_component/ReviewPurpose.tsx
+++ b/src/app/review/write/_component/ReviewPurpose.tsx
@@ -23,6 +23,7 @@ const ReviewPurpose = () => {
         <div className={styles.chipLayout}>
           {data?.purposes?.map((purpose) => (
             <Chip
+              color={"solidBlue"}
               key={purpose.id}
               label={purpose.label ?? ""}
               isSelected={selectedPurposeId === purpose.id}

--- a/src/app/review/write/_section/Step1.tsx
+++ b/src/app/review/write/_section/Step1.tsx
@@ -11,7 +11,7 @@ import ReviewPetInfo from "@app/review/write/_component/ReviewPetInfo";
 import SearchHospital, { Hospital } from "@shared/component/SearchHospital/SearchHospital";
 import { Button } from "@common/component/Button/index";
 import { useFormContext } from "react-hook-form";
-import { ReviewFormData } from "../page";
+import { ReviewFormWithUIData } from "../page";
 import { useRouter } from "next/navigation";
 
 export type PetInfoType = "myPet" | "manual";
@@ -22,15 +22,15 @@ interface Step1Props {
 
 const Step1 = ({ onNext }: Step1Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-  const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
   const [selectedPetInfo, setSelectedPetInfo] = useState<PetInfoType | null>(null);
 
-  const { watch } = useFormContext<ReviewFormData>();
+  const { setValue, watch } = useFormContext<ReviewFormWithUIData>();
 
   const visitedAt = watch("visitedAt");
   const breedId = watch("breedId");
   const gender = watch("gender");
 
+  const selectedHospital = watch("selectedHospital");
   const isFormValid = selectedHospital !== null && visitedAt !== "" && breedId !== -1 && gender !== null;
 
   const router = useRouter();
@@ -44,7 +44,7 @@ const Step1 = ({ onNext }: Step1Props) => {
   };
 
   const handleSelectHospital = (hospital: Hospital | null) => {
-    setSelectedHospital(hospital);
+    setValue("selectedHospital", hospital);
     router.replace(`?hospitalId=${hospital?.id}`);
   };
 
@@ -68,7 +68,7 @@ const Step1 = ({ onNext }: Step1Props) => {
       {/* 중앙 컨텐츠 */}
       <div className={styles.wrapper}>
         {/* 1-1. 병원 검색 */}
-        <ReviewHospital selectedHospital={selectedHospital} handleOpenSearchHospital={handleOpenSearchHospital} />
+        <ReviewHospital handleOpenSearchHospital={handleOpenSearchHospital} />
         {/* 1-2. 날짜 선택 */}
         <ReviewDate />
         {/* 1-3. 동물 정보 */}

--- a/src/app/review/write/_section/Step1.tsx
+++ b/src/app/review/write/_section/Step1.tsx
@@ -22,7 +22,6 @@ interface Step1Props {
 
 const Step1 = ({ onNext }: Step1Props) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-  const [selectedPetInfo, setSelectedPetInfo] = useState<PetInfoType | null>(null);
 
   const { setValue, watch } = useFormContext<ReviewFormWithUIData>();
 
@@ -48,10 +47,9 @@ const Step1 = ({ onNext }: Step1Props) => {
     router.replace(`?hospitalId=${hospital?.id}`);
   };
 
-  // 1-3. petInfo
-  const handleSelectPetInfo = (type: PetInfoType) => {
-    setSelectedPetInfo((prev) => (prev === type ? null : type));
-  };
+  // // 1-3. petInfo
+  // const selectedPetInfo = watch("selectedPetInfoType");
+  // setValue("selectedPetInfoType",  selectedPetInfo === type ? null : type);
 
   const handleGoHospitalDetail = () => {
     window.history.go(-2); //review/agree +1
@@ -72,7 +70,7 @@ const Step1 = ({ onNext }: Step1Props) => {
         {/* 1-2. 날짜 선택 */}
         <ReviewDate />
         {/* 1-3. 동물 정보 */}
-        <ReviewPetInfo selectedPetInfo={selectedPetInfo} onSelectPetInfo={handleSelectPetInfo} />
+        <ReviewPetInfo />
       </div>
 
       <div className={styles.buttonContainer}>

--- a/src/app/review/write/_section/Step3.tsx
+++ b/src/app/review/write/_section/Step3.tsx
@@ -26,7 +26,7 @@ const Step3 = ({ onPrev, onNext }: Step3Props) => {
   const goodReviewIds = watch("goodReviewIds");
   const badReviewIds = watch("badReviewIds");
 
-  const isFromValid = goodReviewIds.length > 0 && badReviewIds.length > 0;
+  const isFromValid = goodReviewIds.length > 0 || badReviewIds.length > 0;
 
   const handleGoHospitalDetail = () => {
     window.history.go(-2);

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -3,7 +3,7 @@ import { IcDeleteBlack } from "@asset/svg/index";
 import { Button } from "@common/component/Button";
 import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomSheet";
 import { useFormContext } from "react-hook-form";
-import { ReviewFormData } from "../page";
+import { ReviewFormData, ReviewFormWithUIData } from "../page";
 import { useReviewPost } from "@app/api/review/write/submit/hook";
 import { useSearchParams } from "next/navigation";
 import axios from "axios";
@@ -33,11 +33,15 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
 
   const { mutate: submitReview } = useReviewPost(hospitalId);
   const { handleSubmit } = useFormContext<ReviewFormData>();
+  const { getValues } = useFormContext<ReviewFormWithUIData>();
 
   const onValid = (data: ReviewFormData) => {
+    const fullData = getValues(); // 전체 데이터 받기
+    const { selectedHospital, selectedPetInfoType, ...submitData }: ReviewFormWithUIData = fullData;
+
     submitReview(
       {
-        ...data,
+        ...submitData,
         gender: data.gender as "F" | "M",
         images: imageNames || undefined,
       },

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -45,7 +45,6 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
         onSuccess: async (res) => {
           const presignedUrls = res?.data?.data?.images;
           if (!presignedUrls || presignedUrls.length === 0) {
-            alert("이미지 업로드 URL이 없습니다.");
             return;
           }
 

--- a/src/app/review/write/_section/Step4.tsx
+++ b/src/app/review/write/_section/Step4.tsx
@@ -44,7 +44,10 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
       {
         onSuccess: async (res) => {
           const presignedUrls = res?.data?.data?.images;
+
+          // 이미지가 없으면 바로 다음 단계로 이동
           if (!presignedUrls || presignedUrls.length === 0) {
+            onNext();
             return;
           }
 
@@ -65,7 +68,6 @@ const Step4 = ({ onPrev, onNext }: Step4Props) => {
                 });
               }),
             );
-
             onNext();
           } catch (uploadErr) {
             console.error("이미지 업로드 실패", uploadErr);

--- a/src/app/review/write/page.tsx
+++ b/src/app/review/write/page.tsx
@@ -5,11 +5,19 @@ import { useReviewFunnel } from "@app/review/write/_hook/useReviewFunnel";
 import { useRouter } from "next/navigation";
 import { PATH } from "@route/path";
 
-import Step1 from "@app/review/write/_section/Step1";
+import Step1, { PetInfoType } from "@app/review/write/_section/Step1";
 import Step2 from "@app/review/write/_section/Step2";
 import Step3 from "@app/review/write/_section/Step3";
 import Step4 from "@app/review/write/_section/Step4";
+import { Hospital } from "@shared/component/SearchHospital/SearchHospital";
 
+// UI 상태 분리
+export interface ReviewExtraData {
+  selectedHospital: Hospital | null;
+  selectedPetInfoType: PetInfoType | null;
+}
+
+// 제출 대상 필드
 export interface ReviewFormData {
   visitedAt: string;
   symptomIds?: number[];
@@ -23,6 +31,8 @@ export interface ReviewFormData {
   gender: "F" | "M" | null;
   weight: number;
 }
+
+export type ReviewFormWithUIData = ReviewFormData & ReviewExtraData;
 
 export const defaultValues: ReviewFormData = {
   visitedAt: "",
@@ -44,8 +54,12 @@ export default function Page() {
 
   const router = useRouter();
 
-  const methods = useForm<ReviewFormData>({
-    defaultValues,
+  const methods = useForm<ReviewFormWithUIData>({
+    defaultValues: {
+      ...defaultValues,
+      selectedHospital: null,
+      selectedPetInfoType: null,
+    },
     mode: "onChange",
   });
 

--- a/src/app/review/write/page.tsx
+++ b/src/app/review/write/page.tsx
@@ -15,6 +15,7 @@ import { Hospital } from "@shared/component/SearchHospital/SearchHospital";
 export interface ReviewExtraData {
   selectedHospital: Hospital | null;
   selectedPetInfoType: PetInfoType | null;
+  petType: string;
 }
 
 // 제출 대상 필드
@@ -59,6 +60,7 @@ export default function Page() {
       ...defaultValues,
       selectedHospital: null,
       selectedPetInfoType: null,
+      petType: "",
     },
     mode: "onChange",
   });

--- a/src/common/component/Chip/Chip.tsx
+++ b/src/common/component/Chip/Chip.tsx
@@ -7,7 +7,7 @@ import { IcDelete } from "@asset/svg/index";
 interface ChipProps {
   label?: string;
   icon?: boolean;
-  color?: "blue" | "gray" | "red" | "border";
+  color?: "blue" | "gray" | "red" | "border" | "solidBlue";
   onClick?: () => void;
   isSelected?: boolean;
   disabled?: boolean;

--- a/src/common/component/Chip/ChipStyle.css.ts
+++ b/src/common/component/Chip/ChipStyle.css.ts
@@ -1,5 +1,5 @@
-import {color, font, semanticColor} from "@style/styles.css.ts";
-import {recipe, RecipeVariants} from "@vanilla-extract/recipes";
+import { color, font, semanticColor } from "@style/styles.css.ts";
+import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
 
 export const chipItem = recipe({
   base: [
@@ -40,6 +40,10 @@ export const chipItem = recipe({
         color: color.red.warning_red200,
         border: `0.1rem solid ${color.red.warning_red200}`,
       },
+      solidBlue: {
+        color: color.primary.blue700,
+        border: `0.1rem solid ${color.primary.blue500}`,
+      },
       border: {
         color: semanticColor.text.normal,
         border: `0.1rem solid ${semanticColor.line.heavy}`,
@@ -71,6 +75,16 @@ export const chipItem = recipe({
       },
       style: {
         backgroundColor: "#F5D8D8",
+      },
+    },
+    {
+      variants: {
+        color: "solidBlue",
+        active: true,
+      },
+      style: {
+        color: color.gray.gray000,
+        background: color.primary.blue500,
       },
     },
   ],

--- a/src/common/component/Radio/Radio.css.ts
+++ b/src/common/component/Radio/Radio.css.ts
@@ -2,6 +2,7 @@ import { style } from "@vanilla-extract/css";
 import { color } from "@style/styles.css";
 
 export const radio = style({
+  flexShrink: "0",
   appearance: "none",
   position: "relative",
   margin: "0rem",

--- a/src/route/path.ts
+++ b/src/route/path.ts
@@ -31,8 +31,9 @@ export const PATH = {
     ROOT: "/review",
     HOSPITALS_DONE: "/review/hospitals/done",
     SEARCH: "/review/search",
-    AGREE:"/review/agree",
+    AGREE: "/review/agree",
     WRITE: "/review/write",
+    COMPLETE: "/review/complete",
   },
   HOSPITAL: {
     ROOT: "/hospital-detail",

--- a/src/shared/component/SearchHospital/Card.css.ts
+++ b/src/shared/component/SearchHospital/Card.css.ts
@@ -25,6 +25,12 @@ export const wrapper = recipe({
   },
 });
 
+export const box = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "1.2rem",
+});
+
 export const infoLayout = style({
   display: "flex",
   flexDirection: "column",

--- a/src/shared/component/SearchHospital/Card.tsx
+++ b/src/shared/component/SearchHospital/Card.tsx
@@ -1,7 +1,6 @@
 // 병원 정보 카드
 import * as styles from "./Card.css";
 import Image from "next/image";
-// ⚠️ 추후 삭제할 이미지
 import nicknameCoco from "@asset/image/nicknameCoco.png";
 import Radio from "@common/component/Radio/Radio";
 
@@ -17,10 +16,12 @@ type CardProps = {
 const Card = ({ id, name, address, selected, imgSrc, onSelect }: CardProps) => {
   return (
     <div className={styles.wrapper({ selected })}>
-      <Radio value={id} checked={selected} onChange={onSelect} />
-      <div className={styles.infoLayout}>
-        <span className={styles.name}>{name}</span>
-        <span className={styles.address}>{address}</span>
+      <div className={styles.box}>
+        <Radio value={id} checked={selected} onChange={onSelect} />
+        <div className={styles.infoLayout}>
+          <span className={styles.name}>{name}</span>
+          <span className={styles.address}>{address}</span>
+        </div>
       </div>
       <Image src={imgSrc ?? nicknameCoco} alt="hospital-exterior" className={styles.img} />
     </div>


### PR DESCRIPTION
## 🔥 Related Issues

- close #397 

## ✅ 작업 리스트 및 🔧 작업 내용

- [x] 리뷰작성 1페이지 - 병원검색 카드 레이아웃 수정
- [x] 리뷰작성 1페이지 - 몸무게 정보 저장
- [x] 리뷰작성 1페이지 - 병원검색 카드 라디오 컴포넌트 찌그러짐 해결
- [x] 리뷰작성 2페이지 - 칩 분기 수정
- [x] 리뷰작성 3페이지 - 진료경험 칩 활성화 기준 수정
- [x] 리뷰작성 4페이지 - 이미지 url 없는경우 alert 삭제
- [x] 리뷰작성 4페이지 - 업로드 버튼 동작 -> 여기 인증할때 이미지 안넣어서 첨부하기
- [x] 리뷰작성 완료페이지 - 리뷰 페이지 작성 완료 후 이동 경로 수정
- [x] 리뷰작성 1페이지 - 동물선택 강아지 고양이 수정시 드롭다운 활성화
- [x] 리뷰 연결 부분 - 이전으로 갈 경우 정보 저장 문제, 하단 버튼 활성화 문제 (정보 저장하는 것과 UI 반영이 일치되지 않고 있음)

## 📣 리뷰어에게
 작업 리스트와 커밋 순서가 일치합니다. (마지막 태스크는 커밋3개 쭉 순서대로 보시면 됩니다.)
 모든 변경사항은 이미지 또는 영상 첨부했습니다. 첨부하지 않은 것 중 변화는 없습니당.
신경쓴다고 썼는데.. QA가 생각보다 더 많네요.. 앞으로 더 작업에 유의하겠습니다.


## 📸 스크린샷 / GIF / Link
- 카드 레이아웃 수정전, 수정후
<img width="200" alt="카드 레이아웃 수정전" src="https://github.com/user-attachments/assets/e659b649-a55a-42d9-90da-275ffe8b1c55" />
<img width="200" alt="카드 레이아웃 수정" src="https://github.com/user-attachments/assets/57d3f10a-beb4-4ead-b901-ab74c9b14e3c" />

- 몸무게 반영 확인
<img width="234" alt="몸무게 반영 확인" src="https://github.com/user-attachments/assets/c78c5532-8bfd-4634-ba19-e5858a90e47c" />

- 병원 카드 라디오 컴포넌트 찌그러짐, 찌그러짐 해결
<img width="200" alt="찌그러짐" src="https://github.com/user-attachments/assets/17f1140a-e161-4f67-9491-5878a611fc4b" />
<img width="200" alt="찌그러짐 해결" src="https://github.com/user-attachments/assets/e548d432-125e-4aac-b638-8c722e39869c" />

- 칩 분기 추가 반영 (배경 블루, 글자 흰색)
<img width="378" alt="칩 분기 추가" src="https://github.com/user-attachments/assets/33741bfb-f887-48cd-8f27-941e72d92b5a" />

- 진료경험 하나만 선택해도 되도록 수정

https://github.com/user-attachments/assets/a7a26d61-b203-4bfc-9f47-5a9c3de44603



- 업로드 버튼 작동

https://github.com/user-attachments/assets/82cd6624-f155-4c52-aca6-995d8d51f205

- 드롭다운 필터링 잘되게 수정(고양이 -> 고양이 드롭다운/ 강아지 -> 강아지 드롭다운)

https://github.com/user-attachments/assets/938e0e03-e878-4156-add9-f289447b9e80

- 다음으로 버튼 이동 시 정보저장 UI반영 및 활성화 버튼 정상화

https://github.com/user-attachments/assets/ac9a0dc6-2f9a-434f-8ef7-3087600f0b0e


