### PR TITLE
[Feat/#419] onboarding, review agree qa

### DIFF
--- a/src/app/onboarding/index/Onboarding.tsx
+++ b/src/app/onboarding/index/Onboarding.tsx
@@ -3,7 +3,6 @@ import Nickname from "./component/nickname/Nickname";
 
 const Onboarding = () => {
   const { isWillRedirect } = useProtectedRoute();
-  console.log("isWillRedirect", isWillRedirect);
 
   if (isWillRedirect) {
     return null;

--- a/src/app/onboarding/index/Onboarding.tsx
+++ b/src/app/onboarding/index/Onboarding.tsx
@@ -3,6 +3,7 @@ import Nickname from "./component/nickname/Nickname";
 
 const Onboarding = () => {
   const { isWillRedirect } = useProtectedRoute();
+  console.log("isWillRedirect", isWillRedirect);
 
   if (isWillRedirect) {
     return null;

--- a/src/app/review/agree/page.tsx
+++ b/src/app/review/agree/page.tsx
@@ -27,7 +27,9 @@ const page = () => {
 
   // url 입력해서 들어오는 경우 방지
   useEffect(() => {
-    if (isReviewAgree) {
+    const isAgreed = isReviewAgree?.data?.isReviewTermsAgree;
+
+    if (isAgreed) {
       router.push(PATH.REVIEW.WRITE);
     }
   }, [isReviewAgree]);

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -57,6 +57,7 @@ export default function ReviewPage() {
   };
 
   const isReviewAgree = useGetReviewAgreementStatus();
+  const isAgreed = isReviewAgree?.data?.isReviewTermsAgree;
 
   const handleFloatingBtnClick = () => {
     // 로그인x -> 로그인 모달
@@ -70,7 +71,7 @@ export default function ReviewPage() {
       return;
     }
     // 리뷰작성 동의 여부에 따라, 동의x -> 리뷰동의 페이지, 동의o -> 바로 리뷰 작성
-    const nextPath = isReviewAgree ? PATH.REVIEW.WRITE : PATH.REVIEW.AGREE;
+    const nextPath = isAgreed ? PATH.REVIEW.WRITE : PATH.REVIEW.AGREE;
     router.push(nextPath);
   };
 
@@ -80,10 +81,7 @@ export default function ReviewPage() {
 
   return (
     <div>
-      <LocationHeader
-        onLocationChange={handleLocationChange}
-        onBottomSheetOpenChange={setIsLocationSheetOpen}
-      />
+      <LocationHeader onLocationChange={handleLocationChange} onBottomSheetOpenChange={setIsLocationSheetOpen} />
 
       <div className={styles.reviewContainer}>
         <div className={styles.reviewList}>

--- a/src/route/useProtectedRoute.tsx
+++ b/src/route/useProtectedRoute.tsx
@@ -11,11 +11,12 @@ export const useProtectedRoute = () => {
   const { data } = useGetMemberInfo();
   const { isError: isNoPet } = useGetPetInfoWithError();
 
+  const isOnOnboardingPage = pathname === PATH.ONBOARDING.ROOT;
   const hasNickName = data?.nickname;
   const isWillRedirect =
     !isAuthenticated ||
-    !hasNickName ||
-    (hasNickName && pathname === "/onboarding") ||
+    (!hasNickName && !isOnOnboardingPage) ||
+    (hasNickName && isOnOnboardingPage) ||
     (isNoPet && pathname === "/community/write");
 
   useEffect(() => {
@@ -25,15 +26,15 @@ export const useProtectedRoute = () => {
     }
 
     if (data) {
-      if (pathname === "/onboarding") {
-        if (hasNickName) {
-          router.replace(PATH.MAIN);
-        }
+      if (hasNickName && isOnOnboardingPage) {
+        router.replace(PATH.MAIN);
+        return;
       }
 
-      if (!hasNickName) {
-        console.log("Redirecting to onboarding...");
+      if (!hasNickName && !isOnOnboardingPage) {
+        console.log("Redirecting to login...");
         router.replace(PATH.ONBOARDING.ROOT);
+        return;
       }
     }
 
@@ -41,7 +42,7 @@ export const useProtectedRoute = () => {
       alert("반려동물을 등록하지 않으면 접근할 수 없습니다.");
       router.push(PATH.MYPAGE.ROOT);
     }
-  }, [data, isNoPet, isAuthenticated]);
+  }, [data, isNoPet, isAuthenticated, pathname]);
 
   return { isNoPet, isWillRedirect };
 };


### PR DESCRIPTION
## 🔥 Related Issues

- close #419 

## ✅ 작업 리스트

- [x] 리뷰 약관 동의 안한 유저 -> 리뷰 동의 페이지로 이동
- [x] 로그인 이후 닉네임 등록 페이지 /onboarding로드 안되는 문제 해결


## 🔧 작업 내용  📣 리뷰어에게
1️⃣ 리뷰 약관에 동의하지 않은 유저임에도 불구하고, 리뷰 작성 페이지로 바로 이동하는 문제가 있었습니다.
리뷰 약관 동의 여부를 판별하는 커스텀 훅을 구현했지만, 응답 데이터의 실제 값을 확인하지 않고 존재 여부만으로 조건 분기를 하여 항상 true로 평가되는 문제가 있었습니다.
응답 객체 내부의 실제 동의 여부(`isReviewTermsAgree`) 값을 기준으로 분기하도록 수정하여 문제를 해결했습니다.

2️⃣ 탈퇴> 회원가입> 닉네임 등록 페이지인 /onboarding로딩 안되는 이슈 발생
참고커밋) "chore: 주석 삭제"
해당 주석이 항상 true로 반환되더라구요, `useProtectedRoute` 로직을 수정했습니다.
수정 포인트는 

> 닉네임이 없는 경우라도,
> 현재 경로가 /onboarding일 때는 리다이렉트하면 안 되는데
> 이전 코드에서는 이 예외 처리가 누락되어 있었기 때문에
> 계속 온보딩 페이지 진입이 막혔던 것입니다.

해서 닉네임 없는 경우 1) 온보딩 페이지인 경우와 2) 온보딩 페이지가 아닌 경우로 나누어 훅을 수정했습니다.


## 📸 스크린샷 / GIF / Link
- 리뷰 약관 동의 페이지로 잘 넘어감 확인

https://github.com/user-attachments/assets/afc2dc2b-9742-47f8-83ef-c792816519a2

- 리뷰 약관 동의 펭페이지로 잘 넘어감

https://github.com/user-attachments/assets/84ad087c-8405-4932-a069-e44a93fa829c

