### PR TITLE
[Bug/#433] 검색 창 필터 바텀 시트의 reload 문제 해결

### DIFF
--- a/src/api/domain/mypage/edit-pet/index.ts
+++ b/src/api/domain/mypage/edit-pet/index.ts
@@ -1,9 +1,6 @@
-import { question } from "./../../../../app/review/write/_component/ReviewHospital.style.css";
-import { nickname } from "./../../../../common/component/SubComment/SubComment.css";
 import { API_PATH } from "@api/constants/apiPath";
-import { del, get, patch } from "@api/index";
+import { get, patch } from "@api/index";
 import { paths } from "@type/schema";
-import { AxiosError } from "axios";
 
 export const getAnimal = async () => {
   type AnimalResponse = paths["/api/dev/animals"]["get"]["responses"]["200"]["content"]["*/*"];

--- a/src/app/community/search/page.tsx
+++ b/src/app/community/search/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { IcLeftarrow, IcSearch } from "@asset/svg";
 import { TextField } from "@common/component/TextField";
-import React, { ChangeEvent, Suspense, useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import React, { ChangeEvent, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { PATH } from "@route/path.ts";
 import { useSearchGet, useSearchPost } from "@api/domain/community/search/hook.ts";
 import { useFilterStore } from "@store/filter.ts";

--- a/src/app/community/search/page.tsx
+++ b/src/app/community/search/page.tsx
@@ -54,7 +54,6 @@ function Search() {
   };
 
   const handleNavigate = (searchText: string) => {
-    onSubmit(searchText);
     router.push(`${PATH.COMMUNITY.SEARCH_DONE}?searchText=${searchText}`);
   };
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #433

## ✅ 작업 리스트

- [x] 검색 창 필터 바텀 시트의 reload 문제 해결
- [x] 무한 검색 문제 해결

## 🔧 작업 내용

> 필터에서 선택했을 때 폴더?열린 상태도 유지되어야할 거 같아요 
> 선택할 때마다 리로드가 되는 거 같네요

해당 VOC 를 해결합니다. 
선택할 때마다 드롭다운이 닫혀버리고 리로드 되는 문제를 해결했어요. 
유저가 클릭할 때는 그냥 select 만 하고, 확인하기 누를 때에만 api 를 호출하도록 했습니다. 


## 📣 리뷰어에게

## 📸 스크린샷 / GIF / Link

[ AS-IS ] 

https://github.com/user-attachments/assets/98f1c7f5-233a-437e-acb5-79773d9b6d74


[ TO-BE ] 


https://github.com/user-attachments/assets/e2e87374-4832-494d-9bb5-c65838646355


