### PR TITLE
[Feature/#458] 이미지 리사이징 

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,5 @@
-import {createVanillaExtractPlugin} from "@vanilla-extract/next-plugin";
-import type {NextConfig} from "next";
+import { createVanillaExtractPlugin } from "@vanilla-extract/next-plugin";
+import type { NextConfig } from "next";
 import * as path from "node:path";
 
 const withVanillaExtract = createVanillaExtractPlugin();
@@ -15,12 +15,21 @@ const nextConfig: NextConfig = {
   // 정적 내보내기 대신 정적 대체 사용
   staticPageGenerationTimeout: 120, // 타임아웃을 2분으로 설정
   images: {
-    unoptimized: true,
+    unoptimized: false,
+    domains: [
+      //prod
+      "cocos-app-data.s3.ap-northeast-2.amazonaws.com",
+      "cocos-member-data.s3.ap-northeast-2.amazonaws.com",
+
+      //dev
+      "cocos-app-data-dev.s3.ap-northeast-2.amazonaws.com",
+      "cocos-member-data-dev.s3.ap-northeast-2.amazonaws.com",
+    ],
   },
   webpack: (config) => {
     // 기존 alias 설정을 유지하면서 확장
     const existingAlias = config.resolve.alias || {};
-    
+
     // 절대 경로에 기반한 alias 설정
     config.resolve.alias = {
       ...existingAlias,

--- a/src/app/community/[postId]/PostDetail.css.ts
+++ b/src/app/community/[postId]/PostDetail.css.ts
@@ -1,5 +1,5 @@
-import {style} from "@vanilla-extract/css";
-import {color, font, semanticColor} from "@style/styles.css.ts";
+import { style } from "@vanilla-extract/css";
+import { color, font, semanticColor } from "@style/styles.css.ts";
 
 export const styles = {
   container: style({
@@ -76,7 +76,6 @@ export const styles = {
   ]),
 
   image: style({
-    width: "100%",
     maxHeight: "33.5rem",
     borderRadius: "0.8rem",
     objectFit: "cover",

--- a/src/app/community/[postId]/page.tsx
+++ b/src/app/community/[postId]/page.tsx
@@ -24,7 +24,6 @@ import SimpleBottomSheet from "@common/component/SimpleBottomSheet/SimpleBottomS
 
 import nocategory from "@asset/image/nocategory.png";
 import { useParams, useRouter } from "next/navigation";
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import { styles } from "./PostDetail.css.ts";
 import { getCategoryResponse } from "../_utills/getPostCategoryLike.ts";
@@ -33,6 +32,7 @@ import Profile from "@app/community/_component/Profile/Profile.tsx";
 import { useAuth } from "@providers/AuthProvider";
 import { useIsPetRegistered } from "@common/hook/useIsPetRegistered";
 import { Modal } from "@common/component/Modal/Modal.tsx";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), { ssr: false });
 
@@ -77,14 +77,12 @@ const Page = () => {
   if (!postData) {
     return (
       <div className={styles.emptyContainer}>
-        <Image
+        <LazyImage
           src={nocategory}
           alt="게시글 없음."
-          style={{
-            width: "27.6074rem",
-            height: "15.4977rem",
-            objectFit: "cover",
-          }}
+          width="27.6rem"
+          height="15.5rem"
+          style={{ objectFit: "cover" }}
         />
         <h1>아직 등록된 게시글이 없어요</h1>
       </div>
@@ -281,7 +279,7 @@ const Page = () => {
           <div className={styles.content}>{postData.content}</div>
         </div>
         {postData.images?.map((image, index) => (
-          <Image
+          <LazyImage
             key={`postImage-${
               // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
               index
@@ -289,8 +287,8 @@ const Page = () => {
             src={image}
             alt="postImage"
             className={styles.image}
-            width={100}
-            height={262}
+            width="100%"
+            height="26.2rem"
           />
         ))}
         <div className={styles.labelWrap}>

--- a/src/app/community/_component/Banner/Banner.css.ts
+++ b/src/app/community/_component/Banner/Banner.css.ts
@@ -1,14 +1,12 @@
-import {style} from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 
 export const bannerContainer = style({
   marginTop: "2rem",
   width: "100%",
   height: "10rem",
+  padding: "0 2rem",
 });
 
 export const bannerImage = style({
-  width: "calc(100% - 4rem)",
-  height: "10rem",
   borderRadius: "8px",
-  margin: "0 2rem", 
 });

--- a/src/app/community/_component/Banner/Banner.tsx
+++ b/src/app/community/_component/Banner/Banner.tsx
@@ -1,11 +1,11 @@
 import * as styles from "./Banner.css.ts";
 import banner from "@asset/image/banner.png";
-import Image from "next/image";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const Banner = () => {
   return (
     <div className={styles.bannerContainer}>
-      <Image src={banner} alt="배너 이미지" className={styles.bannerImage} />
+      <LazyImage src={banner} width="100%" height="10rem" alt="배너 이미지" className={styles.bannerImage} />
     </div>
   );
 };

--- a/src/app/community/_component/Profile/Profile.tsx
+++ b/src/app/community/_component/Profile/Profile.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { IcBaseProfileImage } from "@asset/svg";
 import {
   info,
@@ -7,6 +6,7 @@ import {
   profileContainer,
   profileImage,
 } from "@app/community/_component/Profile/Profile.css.ts";
+import LazyImage from "@common/component/LazyImage";
 
 interface propsType {
   handleProfileClick?: () => void;
@@ -22,7 +22,7 @@ const Profile = (props: propsType) => {
   return (
     <div className={profileContainer} onClick={handleProfileClick}>
       {profileImageData ? (
-        <Image src={profileImageData} alt="userProfile" className={profileImage} width={32} height={32} />
+        <LazyImage src={profileImageData} alt="userProfile" className={profileImage} width="3.2rem" height="3.2rem" />
       ) : (
         <IcBaseProfileImage width={32} height={32} />
       )}

--- a/src/app/community/_component/SelectPost/SelectPost.tsx
+++ b/src/app/community/_component/SelectPost/SelectPost.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import {useCallback, useEffect, useState} from "react";
-import {useRouter} from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import * as styles from "./SelectPost.css.ts";
 import Divider from "@common/component/Divider/Divider.tsx";
-import {IcUnderline} from "@asset/svg";
+import { IcUnderline } from "@asset/svg";
 import Content from "@common/component/Content/Content.tsx";
-import {usePostPostFilters} from "@api/domain/community/search/hook.ts";
-import {postPostFiltersResponse} from "@api/domain/community/search";
-import {PATH} from "@route/path.ts";
-import {formatTime} from "@shared/util/formatTime.ts";
+import { usePostPostFilters } from "@api/domain/community/search/hook.ts";
+import { postPostFiltersResponse } from "@api/domain/community/search";
+import { PATH } from "@route/path.ts";
+import { formatTime } from "@shared/util/formatTime.ts";
 import nocategory from "@asset/image/nocategory.png";
-import Image from "next/image";
 import dynamic from "next/dynamic";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), { ssr: false });
 
@@ -104,7 +104,13 @@ const PostList = () => {
           ))
         ) : (
           <div className={styles.emptyContainer}>
-            <Image src={nocategory} alt="게시글 없음." width={276} height={155} style={{ objectFit: "cover" }} />
+            <LazyImage
+              src={nocategory}
+              alt="게시글 없음."
+              width="27.6rem"
+              height="15.5rem"
+              style={{ objectFit: "cover" }}
+            />
             <h1> 아직 등록된 게시글이 없어요 </h1>
           </div>
         )}

--- a/src/app/community/detail/_section/CommunityDetailContent.tsx
+++ b/src/app/community/detail/_section/CommunityDetailContent.tsx
@@ -7,13 +7,13 @@ import * as styles from "@app/community/detail/SymptomDetail.css.ts";
 import Content from "@common/component/Content/Content.tsx";
 import { PATH } from "@route/path.ts";
 import { formatTime } from "@shared/util/formatTime.ts";
-import Image from "next/image";
 import nocategory from "@asset/image/nocategory.png";
 import { LoadingFallback } from "@app/community/detail/_section/index.tsx";
+import LazyImage from "@common/component/LazyImage";
 
 const EmptyState = () => (
   <div className={styles.emptyContainer}>
-    <Image src={nocategory} alt="게시글 없음." style={{ objectFit: "cover" }} width={276} height={155} />
+    <LazyImage src={nocategory} alt="게시글 없음." width="27.6rem" height="15.5rem" style={{ objectFit: "cover" }} />
     <h1> 아직 등록된 게시글이 없어요 </h1>
   </div>
 );

--- a/src/app/community/detail/page.tsx
+++ b/src/app/community/detail/page.tsx
@@ -11,11 +11,11 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { components } from "@type/schema";
 import nocategory from "@asset/image/nocategory.png";
 import { postPostFiltersRequestType } from "@api/domain/community/search";
-import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Tab from "@common/component/Tab/Tab.tsx";
 import { ReviewDetailContent } from "@app/community/detail/_section";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), {
   ssr: false,
@@ -43,7 +43,7 @@ type ActiveTabType = "review" | "community";
 // 빈 상태 컴포넌트
 const EmptyState = () => (
   <div className={styles.emptyContainer}>
-    <Image src={nocategory} alt="게시글 없음." style={{ objectFit: "cover" }} width={276} height={155} />
+    <LazyImage src={nocategory} alt="게시글 없음." width="27.6rem" height="15.5rem" style={{ objectFit: "cover" }} />
     <h1> 아직 등록된 게시글이 없어요 </h1>
   </div>
 );

--- a/src/app/community/search/done/SearchDone.tsx
+++ b/src/app/community/search/done/SearchDone.tsx
@@ -11,8 +11,8 @@ import FilterBottomSheet from "@shared/component/FilterBottomSheet/FilterBottomS
 import { useGetAnimal, useGetBodies, useGetDisease, useGetSymptoms } from "@api/domain/mypage/edit-pet/hook.ts";
 import { formatTime } from "@shared/util/formatTime";
 import noSearchResult from "@asset/image/noSearchResult.png";
-import Image from "next/image";
 import dynamic from "next/dynamic";
+import LazyImage from "@common/component/LazyImage";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), { ssr: false });
 
@@ -164,12 +164,12 @@ function SearchDone() {
 
         {searchDoneData.length === 0 ? (
           <div className={styles.noSearchData}>
-            <Image
+            <LazyImage
               className={styles.noSearchResultImage}
               src={noSearchResult}
               alt="검색 결과 없음"
-              width={276}
-              height={155}
+              width="27.6rem"
+              height="15.5rem"
             />
             <span className={styles.noSearchText}>검색 결과를 찾지 못했어요.</span>
             <span className={styles.noSearchRecommendText}>

--- a/src/app/hospital-detail/[hospitalId]/_component/HospitalImg/HospitalImg.css.ts
+++ b/src/app/hospital-detail/[hospitalId]/_component/HospitalImg/HospitalImg.css.ts
@@ -7,8 +7,6 @@ export const hospitalHeaderContainer = style({
 });
 
 export const hospitalImage = style({
-  width: "100%",
-  height: "100%",
   objectFit: "cover",
 });
 

--- a/src/app/hospital-detail/[hospitalId]/_component/HospitalImg/HospitalImg.tsx
+++ b/src/app/hospital-detail/[hospitalId]/_component/HospitalImg/HospitalImg.tsx
@@ -1,8 +1,8 @@
 import * as styles from "./HospitalImg.css";
 import hospital_none from "@asset/image/hospital_none.png";
-import Image from "next/image";
 import { IcChevronLeft } from "@asset/svg";
 import { useRouter } from "next/navigation";
+import LazyImage from "@common/component/LazyImage";
 
 interface HospitalHeaderProps {
   image: string;
@@ -20,10 +20,12 @@ export default function HospitalHeader({ image }: HospitalHeaderProps) {
       <button onClick={handleBack} className={styles.backButton}>
         <IcChevronLeft stroke="white" />
       </button>
-      <Image
+      <LazyImage
         src={image || hospital_none}
         alt="병원 이미지"
         className={styles.hospitalImage}
+        width="100%"
+        height="100%"
       />
     </div>
   );

--- a/src/app/hospital-detail/[hospitalId]/_component/ReviewContent/RecentView/RecentView.tsx
+++ b/src/app/hospital-detail/[hospitalId]/_component/ReviewContent/RecentView/RecentView.tsx
@@ -12,9 +12,9 @@ import { useIsPetRegistered } from "@common/hook/useIsPetRegistered";
 import Divider from "@common/component/Divider/Divider";
 import { Modal } from "@common/component/Modal/Modal";
 import FloatingBtn from "@common/component/FloatingBtn/Floating";
-import Image from "next/image";
 import no_review from "@asset/image/no_review.png";
 import { Button } from "@common/component/Button";
+import LazyImage from "@common/component/LazyImage";
 
 interface ReviewSummaryItem {
   id?: number;
@@ -33,8 +33,7 @@ const RecentView = ({ hospitalId }: RecentViewProps) => {
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteHospitalReviews(hospitalId);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteHospitalReviews(hospitalId);
 
   useEffect(() => {
     const element = loadMoreRef.current;
@@ -105,9 +104,7 @@ const RecentView = ({ hospitalId }: RecentViewProps) => {
       <div className={styles.headerRow}>
         <div className={styles.headerLeft}>
           <span className={styles.recentViewTitle}>최근 많이 본 리뷰</span>
-          {totalReviewCount > 0 && (
-            <span className={styles.reviewCount}>+{totalReviewCount}</span>
-          )}
+          {totalReviewCount > 0 && <span className={styles.reviewCount}>+{totalReviewCount}</span>}
         </div>
         {totalReviewCount > 0 && (
           <button className={styles.headerMore} onClick={handleMoreClick}>
@@ -119,73 +116,55 @@ const RecentView = ({ hospitalId }: RecentViewProps) => {
       <div>
         {reviews.length > 0 ? (
           <>
-            {reviews.map(
-              (
-                review: components["schemas"]["HospitalReviewResponse"],
-                index: number
-              ) => (
-                <div
-                  key={review.id}
-                  onClick={() =>
-                    !isAuthenticated && index >= 3 && handleLoginClick()
-                  }
-                >
-                  <HospitalReview
-                    handleProfileClick={() =>
-                      review.memberId && handleProfileClick(review.memberId)
-                    }
-                    handleHospitalDetailClick={handleHospitalDetailClick}
-                    reviewData={{
-                      id: review.id ?? 0,
-                      memberId: review.memberId ?? 0,
-                      nickname: review.nickname ?? "",
-                      breed: review.memberBreed ?? "",
-                      memberBreed: review.memberBreed ?? "",
-                      age: review.age ?? 0,
-                      disease: review.disease ?? "",
-                      visitedAt: review.visitedAt ?? "",
-                      hospitalId: review.hospitalId ?? 0,
-                      hospitalName: review.hospitalName ?? "",
-                      hospitalAddress: review.hospitalAddress ?? "",
-                      content: review.content ?? "",
-                      visitPurpose: review.visitPurpose ?? "",
-                      reviewSummary: {
-                        goodReviews: review.reviewSummary?.goodReviews ?? [],
-                        badReviews: review.reviewSummary?.badReviews ?? [],
-                      },
-                      images: review.images ?? [],
-                      symptoms: review.symptoms ?? [],
-                      animal: review.animal ?? "",
-                      gender: review.gender || "M",
-                      weight: review.weight ?? 0,
-                    }}
-                    isBlurred={!isAuthenticated && index >= 3}
-                  />
-                  {index < reviews.length - 1 && <Divider size="small" />}
-                </div>
-              )
-            )}
-            {hasNextPage && (
-              <div ref={loadMoreRef} style={{ height: "10px" }} />
-            )}
+            {reviews.map((review: components["schemas"]["HospitalReviewResponse"], index: number) => (
+              <div key={review.id} onClick={() => !isAuthenticated && index >= 3 && handleLoginClick()}>
+                <HospitalReview
+                  handleProfileClick={() => review.memberId && handleProfileClick(review.memberId)}
+                  handleHospitalDetailClick={handleHospitalDetailClick}
+                  reviewData={{
+                    id: review.id ?? 0,
+                    memberId: review.memberId ?? 0,
+                    nickname: review.nickname ?? "",
+                    breed: review.memberBreed ?? "",
+                    memberBreed: review.memberBreed ?? "",
+                    age: review.age ?? 0,
+                    disease: review.disease ?? "",
+                    visitedAt: review.visitedAt ?? "",
+                    hospitalId: review.hospitalId ?? 0,
+                    hospitalName: review.hospitalName ?? "",
+                    hospitalAddress: review.hospitalAddress ?? "",
+                    content: review.content ?? "",
+                    visitPurpose: review.visitPurpose ?? "",
+                    reviewSummary: {
+                      goodReviews: review.reviewSummary?.goodReviews ?? [],
+                      badReviews: review.reviewSummary?.badReviews ?? [],
+                    },
+                    images: review.images ?? [],
+                    symptoms: review.symptoms ?? [],
+                    animal: review.animal ?? "",
+                    gender: review.gender || "M",
+                    weight: review.weight ?? 0,
+                  }}
+                  isBlurred={!isAuthenticated && index >= 3}
+                />
+                {index < reviews.length - 1 && <Divider size="small" />}
+              </div>
+            ))}
+            {hasNextPage && <div ref={loadMoreRef} style={{ height: "10px" }} />}
           </>
         ) : (
           <div className={styles.noReviewContainer}>
             <div className={styles.imageContainer}>
-              <Image
+              <LazyImage
                 src={no_review}
                 alt="리뷰 없음"
-                width={127}
-                height={127}
+                width="12.7rem"
+                height="12.7rem"
                 style={{ objectFit: "contain" }}
               />
             </div>
             <p className={styles.noReviewText}>리뷰가 아직 없어요</p>
-            <Button
-              size="large"
-              onClick={handleFloatingBtnClick}
-              label="리뷰 작성하기"
-            />
+            <Button size="large" onClick={handleFloatingBtnClick} label="리뷰 작성하기" />
           </div>
         )}
       </div>
@@ -207,10 +186,7 @@ const RecentView = ({ hospitalId }: RecentViewProps) => {
           bottomAffix={
             <Modal.BottomAffix>
               <Modal.Close label={"취소"} />
-              <Modal.Confirm
-                label={"로그인"}
-                onClick={() => router.push(PATH.LOGIN)}
-              />
+              <Modal.Confirm label={"로그인"} onClick={() => router.push(PATH.LOGIN)} />
             </Modal.BottomAffix>
           }
         >

--- a/src/app/main/_component/HotHospitalItem/HotHospitalItem.css.ts
+++ b/src/app/main/_component/HotHospitalItem/HotHospitalItem.css.ts
@@ -63,7 +63,5 @@ export const hotHospitalSub = style([
 ]);
 
 export const hotHospitalImage = style({
-  width: "7.6rem",
-  height: "7.6rem",
   borderRadius: "0.8rem",
 });

--- a/src/app/main/_component/HotHospitalItem/HotHospitalItem.tsx
+++ b/src/app/main/_component/HotHospitalItem/HotHospitalItem.tsx
@@ -1,7 +1,7 @@
-import Image from "next/image";
 import notFoundGraphic from "@asset/image/notFoundGraphic.png";
 import { StaticImageData } from "next/image";
 import * as styles from "./HotHospitalItem.css.ts";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 interface HotHospitalItemProps {
   id: number;
@@ -44,9 +44,21 @@ const HotHospitalItem = ({
       </div>
       {/* 병원 이미지가 없을 경우를 대비하여 기본 이미지 설정 */}
       {typeof imageSrc !== "string" && !imageSrc ? (
-        <Image src={notFoundGraphic} alt={"병원 이미지"} className={styles.hotHospitalImage} height={76} width={76} />
+        <LazyImage
+          src={notFoundGraphic}
+          alt={"병원 이미지"}
+          className={styles.hotHospitalImage}
+          height="7.6rem"
+          width="7.6rem"
+        />
       ) : (
-        <Image src={imageSrc} alt={"병원 이미지"} className={styles.hotHospitalImage} height={76} width={76} />
+        <LazyImage
+          src={imageSrc}
+          alt={"병원 이미지"}
+          className={styles.hotHospitalImage}
+          height="7.6rem"
+          width="7.6rem"
+        />
       )}
     </div>
   );

--- a/src/app/main/_section/mainHeader/Carousel/mainCarousel.css.ts
+++ b/src/app/main/_section/mainHeader/Carousel/mainCarousel.css.ts
@@ -1,5 +1,5 @@
-import {semanticColor} from "@style/styles.css.ts";
-import {style} from "@vanilla-extract/css";
+import { semanticColor } from "@style/styles.css.ts";
+import { style } from "@vanilla-extract/css";
 
 export const carouselContainer = style({
   position: "relative",

--- a/src/app/main/_section/mainHeader/Carousel/mainCarousel.tsx
+++ b/src/app/main/_section/mainHeader/Carousel/mainCarousel.tsx
@@ -1,5 +1,5 @@
 import useEmblaCarousel from "embla-carousel-react";
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import * as styles from "./mainCarousel.css.ts";
 import Image, { StaticImageData } from "next/image";
 

--- a/src/app/main/_section/symptom/Symptom.tsx
+++ b/src/app/main/_section/symptom/Symptom.tsx
@@ -8,6 +8,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { usePostPostFilters } from "@api/domain/community/search/hook.ts";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 function SymptomContent() {
   const searchParams = useSearchParams();
@@ -56,7 +57,9 @@ function SymptomContent() {
             aria-label={`증상 부위: ${bodyPart.name}`}
             type="button"
           >
-            {bodyPart.image && <Image src={bodyPart.image} alt={`${bodyPart.name} 아이콘`} width={56} height={56} />}
+            {bodyPart.image && (
+              <LazyImage src={bodyPart.image} alt={`${bodyPart.name} 아이콘`} width="5.6rem" height="5.6rem" />
+            )}
             <p className={styles.symptomName}>{bodyPart.name}</p>
           </button>
         ))}

--- a/src/app/main/_section/symptomDetail/SymptomDetail.tsx
+++ b/src/app/main/_section/symptomDetail/SymptomDetail.tsx
@@ -12,6 +12,7 @@ import nocategory from "@asset/image/nocategory.png";
 import { useFilterStore } from "@store/filter.ts";
 import { postPostFiltersRequestType } from "@api/domain/community/search";
 import Image from "next/image";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const symptomMapping: { [key: string]: string } = {
   1: "피부/털",
@@ -71,11 +72,11 @@ function SymptomDetailContent() {
           />
         </div>
         <div className={styles.emptyContainer}>
-          <Image
+          <LazyImage
             src={nocategory}
             alt="게시글 없음."
-            width={276}
-            height={155}
+            width="27.6rem"
+            height="15.5rem"
             style={{ objectFit: "cover" }}
           />
           <h1> 아직 등록된 게시글이 없어요 </h1>

--- a/src/app/mypage/_component/ProfileSection/ProfileSection.tsx
+++ b/src/app/mypage/_component/ProfileSection/ProfileSection.tsx
@@ -3,7 +3,6 @@ import * as styles from "../../_style/mypage.css";
 import Divider from "@common/component/Divider/Divider";
 import { Button } from "@common/component/Button";
 import { IcChevronRight, IcPlus } from "@asset/svg";
-import Image from "next/image";
 import AddFavoriteHospital from "../AddFavoriteHospital";
 import { Disease, MemberInfo } from "../../_hooks/useMypageState";
 import { PetInfo, useProfileSectionState } from "@app/mypage/_hooks/useProfileSectionState";
@@ -11,6 +10,7 @@ import { useMypageMemberInfo } from "@app/mypage/_store/mypageStore";
 import { useRouter } from "next/navigation";
 import { PATH } from "@route/path";
 import { useAuth } from "@providers/AuthProvider";
+import LazyImage from "@common/component/LazyImage";
 
 interface ProfileSectionProps {
   onNavigateToEditPet: () => void;
@@ -75,7 +75,13 @@ const LoggedProfile = ({
 }) => (
   <div className={styles.loginProfile}>
     {member.profileImage && (
-      <Image className={styles.profileImage} alt="프로필 이미지" src={member.profileImage} width={68} height={68} />
+      <LazyImage
+        className={styles.profileImage}
+        alt="프로필 이미지"
+        src={member.profileImage}
+        width="4.8rem"
+        height="4.8rem"
+      />
     )}
     <span className={styles.userProfileText}>{member.nickname}</span>
     <Divider size="small" />
@@ -107,7 +113,13 @@ const PetProfile = ({
     return (
       <div className={styles.animalProfileWrapper}>
         {petInfo.petImage && (
-          <Image className={styles.animalImage} alt="프로필이미지" src={petInfo.petImage} width={52} height={52} />
+          <LazyImage
+            className={styles.animalImage}
+            alt="프로필이미지"
+            src={petInfo.petImage}
+            width="5.2rem"
+            height="5.2rem"
+          />
         )}
         <div className={styles.animalProfileTextWrapper}>
           <span className={styles.animalMainText}>

--- a/src/app/mypage/_style/mypage.css.ts
+++ b/src/app/mypage/_style/mypage.css.ts
@@ -67,13 +67,7 @@ export const userProfile = style([
   },
 ]);
 
-export const profileImage = style([
-  a.profileImageBase,
-  {
-    width: "4.8rem",
-    height: "4.8rem",
-  },
-]);
+export const profileImage = style([a.profileImageBase]);
 
 export const userProfileText = style([
   font.heading02,

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import {useRouter} from "next/navigation";
+import { useRouter } from "next/navigation";
 import * as styles from "./notFound/NotFound.css";
 import notFoundGraphic from "@asset/image/notFoundGraphic.png";
-import {PATH} from "@route/path";
-import Image from "next/image";
-import {useEffect, useState} from "react";
+import { PATH } from "@route/path";
+import { useEffect, useState } from "react";
+import LazyImage from "@common/component/LazyImage";
 
 const REDIRECT_TIME = 5;
 
@@ -32,19 +32,10 @@ export default function NotFound() {
   return (
     <section className={styles.notFoundContainer}>
       <article className={styles.notFoundeWrapper}>
-        <Image
-          className={styles.notFoundImage}
-          src={notFoundGraphic}
-          alt="404"
-          width={196}
-          height={196}
-        />
+        <LazyImage className={styles.notFoundImage} src={notFoundGraphic} alt="404" width="29.2rem" height="16.5rem" />
         <div className={styles.notFoundTextWrapper}>
           <h1 className={styles.nothingText}>앗, 이곳엔 아무것도 없어요</h1>
-          <p
-            className={styles.goHomeText}
-            onClick={() => router.push(PATH.MAIN)}
-          >
+          <p className={styles.goHomeText} onClick={() => router.push(PATH.MAIN)}>
             홈으로 가기
           </p>
           <p style={{ fontSize: "14px", color: "#888", marginTop: "10px" }}>

--- a/src/app/notFound/NotFound.tsx
+++ b/src/app/notFound/NotFound.tsx
@@ -1,14 +1,14 @@
-import {Link} from "react-router-dom";
+import { Link } from "react-router-dom";
 import * as styles from "./NotFound.css";
 import notFoundGraphic from "@asset/image/notFoundGraphic.png";
-import {PATH} from "@route/path";
-import Image from "next/image";
+import { PATH } from "@route/path";
+import LazyImage from "@common/component/LazyImage";
 
 const NotFound = () => {
   return (
     <section className={styles.notFoundContainer}>
       <article className={styles.notFoundeWrapper}>
-        <Image className={styles.notFoundImage} src={notFoundGraphic} alt="404" width={196} height={196} />
+        <LazyImage className={styles.notFoundImage} src={notFoundGraphic} alt="404" width="19.6rem" height="19.6rem" />
         <div className={styles.notFoundTextWrapper}>
           <h1 className={styles.nothingText}>앗, 이곳엔 아무것도 없어요</h1>
           <Link to={PATH.MAIN} className={styles.goHomeText}>

--- a/src/app/onboarding/index/component/nickname/Nickname.tsx
+++ b/src/app/onboarding/index/component/nickname/Nickname.tsx
@@ -9,11 +9,11 @@ import nicknameCoco from "@asset/image/nicknameCoco.png";
 import { useCheckNicknameGet } from "@api/domain/onboarding/nicknameDuplicate/hook";
 import { usePatchNickname } from "@api/domain/onboarding/nickname/hook";
 import { PATH } from "@route/path";
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import { ONBOARDING_GUIDE } from "../../constant/onboardingGuide.ts";
 import Title from "../../common/title/Title.tsx";
 import Docs from "../../common/docs/Docs.tsx";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), { ssr: false });
 
@@ -70,7 +70,13 @@ const Nickname = () => {
       {/* 상단 영역 */}
       <div className={styles.layout}>
         <div>
-          <Image src={nicknameCoco} alt="onboarding-character" className={styles.imgStyle} width={276} height={155} />
+          <LazyImage
+            src={nicknameCoco}
+            alt="onboarding-character"
+            className={styles.imgStyle}
+            width="27.6rem"
+            height="15.5rem"
+          />
           <Title text={ONBOARDING_GUIDE.nickname.title} />
           <Docs text={ONBOARDING_GUIDE.nickname.docs} />
         </div>

--- a/src/app/register-pet/index/common/dualOptionSelector/DualOptionSelector.tsx
+++ b/src/app/register-pet/index/common/dualOptionSelector/DualOptionSelector.tsx
@@ -1,7 +1,8 @@
 import * as styles from "./DualOptionSelector.css";
-import {useState} from "react";
-import {animalGetResponse} from "@api/domain/register-pet/animal/index";
+import { useState } from "react";
+import { animalGetResponse } from "@api/domain/register-pet/animal/index";
 import Image, { StaticImageData } from "next/image";
+import LazyImage from "@common/component/LazyImage";
 
 interface DualOptionSelectorProps {
   data: {
@@ -38,7 +39,7 @@ const DualOptionSelector = ({ data, onSelect }: DualOptionSelectorProps) => {
           onClick={() => handleOptionClick(item.id, item.name)}
         >
           {item.name}
-          {item.image && <Image src={item.image} alt={item.name || ""} width={104} height={59} />}
+          {item.image && <LazyImage src={item.image} alt={item.name || ""} width="10.4rem" height="5.9rem" />}
         </div>
       ))}
     </div>

--- a/src/app/register-pet/index/component/petName/PetName.tsx
+++ b/src/app/register-pet/index/component/petName/PetName.tsx
@@ -13,6 +13,7 @@ import { ONBOARDING_GUIDE } from "../../../../onboarding/index/constant/onboardi
 import Title from "../../../../onboarding/index/common/title/Title.tsx";
 import Docs from "../../../../onboarding/index/common/docs/Docs.tsx";
 import { useIsPetRegistered } from "@common/hook/useIsPetRegistered.ts";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 interface PetNameProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -59,7 +60,13 @@ const PetName = ({ setStep, updatePetData }: PetNameProps) => {
       {/* 상단 영역 */}
       <div className={styles.layout}>
         <div className={styles.gap}>
-          <Image src={petNameBori} alt="onboarding-character" className={styles.imgStyle} width={276} height={155} />
+          <LazyImage
+            src={petNameBori}
+            alt="onboarding-character"
+            className={styles.imgStyle}
+            width="27.6rem"
+            height="15.5rem"
+          />
           <Title text={ONBOARDING_GUIDE.petName.title} />
           <Docs text={ONBOARDING_GUIDE.petName.docs} />
         </div>

--- a/src/app/review/_components/hospitalList/hospitalList.tsx
+++ b/src/app/review/_components/hospitalList/hospitalList.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { HospitalListResponse, Hospital } from "@api/domain/hospitals";
 import { PATH } from "@route/path";
+import LazyImage from "@common/component/LazyImage";
 
 interface Location {
   id: number;
@@ -23,21 +24,16 @@ interface HospitalListProps {
   selectedLocation?: Location;
 }
 
-export default function HospitalList({
-  title,
-  highlightText,
-  selectedLocation,
-}: HospitalListProps) {
+export default function HospitalList({ title, highlightText, selectedLocation }: HospitalListProps) {
   const { ref, inView } = useInView();
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
-    useInfiniteHospitalList({
-      locationType: selectedLocation?.type || "CITY",
-      locationId: selectedLocation?.id,
-      size: 10,
-      sortBy: "REVIEW",
-      image: "",
-    });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } = useInfiniteHospitalList({
+    locationType: selectedLocation?.type || "CITY",
+    locationId: selectedLocation?.id,
+    size: 10,
+    sortBy: "REVIEW",
+    image: "",
+  });
 
   useEffect(() => {
     refetch();
@@ -57,33 +53,25 @@ export default function HospitalList({
       <div className={styles.listContainer}>
         {data?.pages?.map((page: HospitalListResponse, pageIndex: number) =>
           page.hospitals?.map((hospital: Hospital) => (
-            <div
-              key={`${pageIndex}-${hospital.id}`}
-              className={styles.hospitalItem}
-            >
-              <Link
-                href={`${PATH.HOSPITAL.ROOT}/${hospital.id}`}
-                className={styles.link}
-              >
+            <div key={`${pageIndex}-${hospital.id}`} className={styles.hospitalItem}>
+              <Link href={`${PATH.HOSPITAL.ROOT}/${hospital.id}`} className={styles.link}>
                 <div className={styles.hospitalInfo}>
                   <h3 className={styles.hospitalName}>{hospital.name}</h3>
                   <p className={styles.hospitalAddress}>{hospital.address}</p>
-                  <p className={styles.reviewCount}>
-                    리뷰 {hospital.reviewCount}
-                  </p>
+                  <p className={styles.reviewCount}>리뷰 {hospital.reviewCount}</p>
                 </div>
                 {hospital.image && (
-                  <Image
+                  <LazyImage
                     src={hospital.image}
                     alt={hospital.name}
-                    width={80}
-                    height={80}
+                    width="8rem"
+                    height="8rem"
                     className={styles.hospitalImage}
                   />
                 )}
               </Link>
             </div>
-          ))
+          )),
         )}
         <div ref={ref}>{isFetchingNextPage && "로딩 중"}</div>
       </div>

--- a/src/app/review/agree/page.tsx
+++ b/src/app/review/agree/page.tsx
@@ -15,6 +15,7 @@ import { useAgreeReviewMutation } from "@app/api/review/agree/hook";
 import { useRouter } from "next/navigation";
 import { PATH } from "@route/path";
 import { useGetReviewAgreementStatus } from "@app/api/review/agree/hook";
+import LazyImage from "@common/component/LazyImage";
 
 const page = () => {
   const CHECKBOX_COUNT = CHECKBOX_TEXTS.length;
@@ -26,13 +27,13 @@ const page = () => {
   const isReviewAgree = useGetReviewAgreementStatus();
 
   // url 입력해서 들어오는 경우 방지
-  useEffect(() => {
-    const isAgreed = isReviewAgree?.data?.isReviewTermsAgree;
+  // useEffect(() => {
+  //   const isAgreed = isReviewAgree?.data?.isReviewTermsAgree;
 
-    if (isAgreed) {
-      router.push(PATH.REVIEW.WRITE);
-    }
-  }, [isReviewAgree]);
+  //   if (isAgreed) {
+  //     router.push(PATH.REVIEW.WRITE);
+  //   }
+  // }, [isReviewAgree]);
 
   const handleClickBtn = () => {
     mutation.mutate(undefined, {
@@ -74,13 +75,20 @@ const page = () => {
       />
       <div className={style.wrapper}>
         <section className={style.topLayout}>
-          <Image src={danger} alt="주의 표시" className={style.dangerImg} />
+          <LazyImage src={danger} alt="주의 표시" className={style.dangerImg} width="4.8rem" height="4.8rem" />
           <h2>{TITLE.main}</h2>
           <h2 className={style.title}>{TITLE.sub}</h2>
           <p className={style.docs}>{TITLE.descriptions[0]}</p>
           <p className={style.docs}>{TITLE.descriptions[1]}</p>
         </section>
-        <Image src={reviewNoticeFrame} alt="리뷰작성 유의사항 이미지" priority className={style.mainImg} />
+        <LazyImage
+          src={reviewNoticeFrame}
+          alt="리뷰작성 유의사항 이미지"
+          priority
+          className={style.mainImg}
+          width="26rem"
+          height="19.5rem"
+        />
         <section className={style.bottomLayout}>
           {CHECKBOX_TEXTS.map((text, idx) => (
             <div key={idx}>

--- a/src/app/review/agree/style.css.ts
+++ b/src/app/review/agree/style.css.ts
@@ -39,9 +39,6 @@ export const docs = style([
 ]);
 
 export const mainImg = style({
-  width: "26rem",
-  height: "19.5rem",
-
   margin: "2.4rem 0 4.8rem",
 });
 

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@providers/AuthProvider";
 import { useIsPetRegistered } from "@common/hook/useIsPetRegistered";
 import { Modal } from "@common/component/Modal/Modal.tsx";
 import { useGetReviewAgreementStatus } from "@app/api/review/agree/hook";
+import LazyImage from "@common/component/LazyImage";
 
 interface Location {
   id: number;
@@ -117,7 +118,7 @@ export default function ReviewPage() {
                   </div>
                 ))}
               </div>
-              <Image src={banner} alt="banner" className={styles.bannerContainer} />
+              <LazyImage src={banner} alt="banner" className={styles.bannerContainer} width="100%" height="10rem" />
             </div>
             <p className={styles.hospitalListText}>믿고 찾는 인기 병원</p>
             <HospitalList

--- a/src/app/review/search/done/HospitalSearchDone.css.ts
+++ b/src/app/review/search/done/HospitalSearchDone.css.ts
@@ -27,8 +27,6 @@ export const styles = {
     paddingBottom: "10.4rem",
   }),
   noSearchResultImage: style({
-    width: "26.3rem",
-    height: "15.5rem",
     objectFit: "cover",
   }),
   noSearchText: style([

--- a/src/app/review/search/done/HospitalSearchDone.tsx
+++ b/src/app/review/search/done/HospitalSearchDone.tsx
@@ -11,6 +11,7 @@ import Divider from "@common/component/Divider/Divider.tsx";
 import { useGetHospitalSearch } from "@api/domain/hospitals/search/hook";
 import { PATH } from "@route/path.ts";
 import { Hospital } from "@api/domain/hospitals/search";
+import LazyImage from "@common/component/LazyImage";
 
 const Loading = dynamic(() => import("@common/component/Loading/Loading.tsx"), {
   ssr: false,
@@ -47,9 +48,7 @@ function HospitalSearchDoneContent() {
     }
   };
 
-  const onTextFieldClear = (
-    e: React.MouseEvent<HTMLButtonElement | SVGSVGElement>
-  ) => {
+  const onTextFieldClear = (e: React.MouseEvent<HTMLButtonElement | SVGSVGElement>) => {
     e.stopPropagation();
     setSearchText("");
     router.push(PATH.REVIEW.SEARCH);
@@ -66,15 +65,11 @@ function HospitalSearchDoneContent() {
   const defaultImage = noSearchResult.src;
 
   if (isPending) {
-    return <Loading height={80} />;
+    // return <Loading height={80} />;
   }
 
   if (isError) {
-    return (
-      <div className={styles.noSearchData}>
-        에러가 발생했습니다. 잠시 후 다시 시도해 주세요.
-      </div>
-    );
+    return <div className={styles.noSearchData}>에러가 발생했습니다. 잠시 후 다시 시도해 주세요.</div>;
   }
 
   return (
@@ -93,16 +88,14 @@ function HospitalSearchDoneContent() {
       </div>
       {hospitals.length === 0 ? (
         <div className={styles.noSearchData}>
-          <Image
+          <LazyImage
             className={styles.noSearchResultImage}
             src={noSearchResult}
             alt="검색 결과 없음"
-            width={276}
-            height={155}
+            width="26.3rem"
+            height="15.5rem"
           />
-          <span className={styles.noSearchText}>
-            검색 결과를 찾지 못했어요.
-          </span>
+          <span className={styles.noSearchText}>검색 결과를 찾지 못했어요.</span>
           <span className={styles.noSearchRecommendText}>
             {"검색어를 확인하거나"}
             <br />
@@ -125,12 +118,7 @@ function HospitalSearchDoneContent() {
                   </p>
                 </div>
                 <div className={styles.hospitalImage}>
-                  <Image
-                    src={hospital.image || defaultImage}
-                    alt={hospital.name}
-                    width={100}
-                    height={100}
-                  />
+                  <LazyImage src={hospital.image || defaultImage} alt={hospital.name} width="10rem" height="10rem" />
                 </div>
               </div>
               <Divider size="small" />

--- a/src/app/review/style.css.ts
+++ b/src/app/review/style.css.ts
@@ -91,10 +91,7 @@ export const hospitalAddress = style([
   },
 ]);
 
-export const bannerContainer = style({
-  width: "100%",
-  height: "10rem",
-});
+export const bannerContainer = style({});
 
 export const hospitalListText = style([
   font.label01,

--- a/src/app/review/write/_component/ReviewHospital.style.css.ts
+++ b/src/app/review/write/_component/ReviewHospital.style.css.ts
@@ -57,8 +57,6 @@ export const hospitalInfo = style([
 ]);
 
 export const img = style({
-  width: "4.8rem",
-  height: "4.8rem",
   borderRadius: "8px",
 });
 

--- a/src/app/review/write/_component/ReviewHospital.tsx
+++ b/src/app/review/write/_component/ReviewHospital.tsx
@@ -6,6 +6,7 @@ import nicknameCoco from "@asset/image/nicknameCoco.png";
 import Image from "next/image";
 import { useFormContext } from "react-hook-form";
 import { ReviewFormWithUIData } from "../page";
+import LazyImage from "@common/component/LazyImage";
 interface ReviewHospitalProps {
   handleOpenSearchHospital: () => void;
 }
@@ -31,7 +32,14 @@ const ReviewHospital = ({ handleOpenSearchHospital }: ReviewHospitalProps) => {
               </span>
             </div>
             {/* ⚠️ api 연동시 이미지도 받아와야 함 */}
-            <Image src={nicknameCoco} alt="hospital-exterior" className={styles.img} priority />
+            <LazyImage
+              src={nicknameCoco}
+              alt="hospital-exterior"
+              className={styles.img}
+              priority
+              width="4.8rem"
+              height="4.8rem"
+            />
           </div>
         ) : (
           <button onClick={handleOpenSearchHospital} className={styles.myPetInfoBtn({ selected: false })}>

--- a/src/app/review/write/_section/Step3.style.css.ts
+++ b/src/app/review/write/_section/Step3.style.css.ts
@@ -12,10 +12,7 @@ export const TopLayout = style({
   backgroundColor: color.gray.gray000,
 });
 
-export const img = style({
-  width: "8rem",
-  height: "6rem",
-});
+export const img = style({});
 
 export const titleBox = style({
   display: "flex",

--- a/src/app/review/write/_section/Step3.tsx
+++ b/src/app/review/write/_section/Step3.tsx
@@ -10,6 +10,7 @@ import feedbackImg from "@asset/image/reviewFeedback.png";
 import { FEEDBACK_CATEGORIES } from "../constant";
 import { useFormContext } from "react-hook-form";
 import { ReviewFormData } from "../page";
+import LazyImage from "@common/component/LazyImage";
 
 type CategoryType = "good" | "bad";
 
@@ -42,7 +43,7 @@ const Step3 = ({ onPrev, onNext }: Step3Props) => {
       <div className={styles.backgroundColor}>
         {/* 타이틀 */}
         <section className={styles.TopLayout}>
-          <Image src={feedbackImg} alt="review-feedback img" className={styles.img} />
+          <LazyImage src={feedbackImg} alt="review-feedback img" className={styles.img} width="8rem" height="6rem" />
           <div className={styles.titleBox}>
             <h1 className={styles.title}>진료 경험은 어땠나요?</h1>
             <div>

--- a/src/common/component/Content/Content.css.ts
+++ b/src/common/component/Content/Content.css.ts
@@ -64,8 +64,6 @@ export const styles = {
   ]),
   postImage: style({
     flexShrink: 0,
-    width: "7.6rem",
-    height: "7.6rem",
     objectFit: "cover",
     borderRadius: "0.8rem",
   }),

--- a/src/common/component/Content/Content.tsx
+++ b/src/common/component/Content/Content.tsx
@@ -2,7 +2,7 @@
 
 import { IcCurious, IcLikeDisabled, IcoMessage } from "@asset/svg";
 import { styles } from "@common/component/Content/Content.css.ts";
-import Image from "next/image";
+import LazyImage from "@common/component/LazyImage";
 
 interface ContentPropTypes {
   breed?: string;
@@ -74,7 +74,7 @@ const Content = ({
       </div>
       {postImage && (
         <div className={styles.postImage}>
-          <Image className={styles.postImage} src={postImage} alt="Post image" width={76} height={76} />
+          <LazyImage className={styles.postImage} src={postImage} alt="Post image" width="7.6rem" height="7.6rem" />
         </div>
       )}
     </div>

--- a/src/common/component/LazyImage.tsx
+++ b/src/common/component/LazyImage.tsx
@@ -1,0 +1,27 @@
+import Image, { ImageProps } from "next/image";
+import React from "react";
+import { sizeOfRem } from "@style/global.css";
+
+type sizeType = `${number}rem` | `${number}%`;
+
+interface LazyImageProps extends Omit<ImageProps, "width" | "height"> {
+  width: sizeType;
+  height: sizeType;
+}
+
+export default function LazyImage(props: LazyImageProps) {
+  const { width, height, ...rest } = props;
+  const isPercent = width.includes("%") || height.includes("%");
+
+  if (isPercent) {
+    return (
+      <div style={{ position: "relative", width, height }}>
+        <Image fill {...rest} />
+      </div>
+    );
+  }
+
+  const widthPx = Number(width.replace("rem", "")) * sizeOfRem;
+  const heightPx = Number(height.replace("rem", "")) * sizeOfRem;
+  return <Image width={widthPx} height={heightPx} style={{ width, height }} {...rest} />;
+}

--- a/src/common/component/Nav/Nav.tsx
+++ b/src/common/component/Nav/Nav.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import * as styles from "./Nav.css";
 import { NAV_CONTENT } from "./constant";
 import { PATH } from "@route/path";
-import Image from "next/image";
+import LazyImage from "@common/component/LazyImage";
 
 type CommunityContent = {
   id: string;
@@ -59,12 +59,11 @@ const Nav = ({ content, type = "nav" }: Props) => {
               })}
             >
               {communityItem.image && (
-                <Image
+                <LazyImage
                   src={communityItem.image}
                   alt={communityItem.name || "Unnamed"}
-                  width={72}
-                  height={72}
-                  style={{ width: "7.2rem" }}
+                  width={"7.2rem"}
+                  height={"7.2rem"}
                 />
               )}
               <span>{communityItem.name || "Unnamed"}</span>
@@ -73,8 +72,7 @@ const Nav = ({ content, type = "nav" }: Props) => {
         }
 
         const navItem = item as (typeof NAV_CONTENT)[number];
-        const SvgComponent =
-          activeItem === navItem.id ? navItem.activeSvg : navItem.svg;
+        const SvgComponent = activeItem === navItem.id ? navItem.activeSvg : navItem.svg;
 
         return (
           <button

--- a/src/shared/component/HospitalReview/HospitalReview.tsx
+++ b/src/shared/component/HospitalReview/HospitalReview.tsx
@@ -10,6 +10,7 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 import ImageGalleryModal from "@shared/component/ImageGalleryModal.tsx";
 import { postHospitalReviewsResponseData } from "@api/domain/community/detail";
+import LazyImage from "@common/component/LazyImage.tsx";
 
 export interface ReviewItemType {
   id?: number;
@@ -126,13 +127,13 @@ const HospitalReview = (props: propsType) => {
         {isReviewImage && (
           <div className={styles.imagesContainer}>
             {reviewData.images?.map((image, index) => (
-              <Image
+              <LazyImage
                 key={`${image}-${index}`}
                 className={styles.reviewImage}
                 src={image}
                 alt="Post image"
-                width={76}
-                height={76}
+                width={"7.6rem"}
+                height={"7.6rem"}
                 onClick={() => handleImageClick(index)}
               />
             ))}

--- a/src/shared/component/ImageGalleryModal.tsx
+++ b/src/shared/component/ImageGalleryModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import Image from "next/image";
 import { StaticImageData } from "next/image";
+import LazyImage from "@common/component/LazyImage";
 
 interface ImageGalleryModalProps {
   isOpen: boolean;
@@ -9,12 +10,7 @@ interface ImageGalleryModalProps {
   onClose: () => void;
 }
 
-const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
-  isOpen,
-  images,
-  currentIndex,
-  onClose,
-}) => {
+const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({ isOpen, images, currentIndex, onClose }) => {
   // 스크롤 위치를 저장하기 위한 ref
   const scrollPositionRef = useRef(0);
 
@@ -85,7 +81,7 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
           width: "100%",
           padding: "1.6rem",
           display: "flex",
-          justifyContent: "center", 
+          justifyContent: "center",
           alignItems: "center",
           color: "white",
         }}
@@ -129,7 +125,7 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
           }}
           onDoubleClick={preventDoubleClick}
         >
-          <Image
+          <LazyImage
             src={images[currentIndex]}
             alt={`이미지 ${currentIndex + 1}`}
             style={{
@@ -138,15 +134,13 @@ const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
               objectFit: "contain",
               pointerEvents: "none", // 이미지 상호작용 비활성화
             }}
-            width={500}
-            height={500}
+            width={"50rem"}
+            height={"50rem"}
             onClick={(e) => e.stopPropagation()} // 이미지 클릭이 모달 닫기로 이어지지 않도록
             onDoubleClick={preventDoubleClick} // 더블클릭 비활성화
             unoptimized // 이미지 최적화 비활성화로 일부 상호작용 방지
           />
         </div>
-
-        
       </div>
     </div>
   );

--- a/src/shared/component/NoData/NoData.tsx
+++ b/src/shared/component/NoData/NoData.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import nocategory from "@asset/image/nocategory.png";
 import FloatingBtn from "@common/component/FloatingBtn/Floating.tsx";
 import { HTMLAttributes } from "react";
+import LazyImage from "@common/component/LazyImage";
 
 interface noDataType extends HTMLAttributes<HTMLDivElement> {
   label?: string;
@@ -12,11 +13,11 @@ interface noDataType extends HTMLAttributes<HTMLDivElement> {
 const NoData = ({ label = "아직 등록된 게시글이 없어요", onBtnClick, ...rest }: noDataType) => {
   return (
     <div className={styles.emptyContainer} {...rest}>
-      <Image
+      <LazyImage
         src={nocategory}
         alt="게시글 없음."
-        width={276}
-        height={155}
+        width={"27.6rem"}
+        height={"15.5rem"}
         style={{
           objectFit: "cover",
         }}

--- a/src/shared/component/ReviewItem/ReviewItem.tsx
+++ b/src/shared/component/ReviewItem/ReviewItem.tsx
@@ -7,8 +7,8 @@ import Profile from "@app/community/_component/Profile/Profile.tsx";
 import Divider from "@common/component/Divider/Divider.tsx";
 import { Separated } from "react-simplikit";
 import { motion } from "framer-motion";
-import Image from "next/image";
 import ImageGalleryModal from "@shared/component/ImageGalleryModal.tsx";
+import LazyImage from "@common/component/LazyImage";
 
 export interface ReviewItemType {
   id: number;
@@ -49,12 +49,7 @@ interface propsType {
  * @param isBlurred 리뷰가 블러 처리되어야 하는지 여부
  */
 const HospitalReview = (props: propsType) => {
-  const {
-    handleProfileClick,
-    handleHospitalDetailClick,
-    reviewData,
-    isBlurred = false,
-  } = props;
+  const { handleProfileClick, handleHospitalDetailClick, reviewData, isBlurred = false } = props;
   const [isExpanded, setIsExpanded] = useState(false);
   const [isImageGalleryModalOpen, setIsImageGalleryModalOpen] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
@@ -81,22 +76,11 @@ const HospitalReview = (props: propsType) => {
         petAge={reviewData.petAge}
       />
       <article className={isBlurred ? styles.blurEffect : undefined}>
-        <div
-          className={styles.hospitalDetail}
-          onClick={handleHospitalDetailClick}
-        >
+        <div className={styles.hospitalDetail} onClick={handleHospitalDetailClick}>
           <div className={styles.hospitalName}>{reviewData.hospitalName}</div>
-          <div className={styles.hospitalAddress}>
-            {reviewData.hospitalAddress}
-          </div>
+          <div className={styles.hospitalAddress}>{reviewData.hospitalAddress}</div>
         </div>
-        <div
-          className={
-            isExpanded ? styles.reviewContentExpanded : styles.reviewContent
-          }
-        >
-          {reviewData.content}
-        </div>
+        <div className={isExpanded ? styles.reviewContentExpanded : styles.reviewContent}>{reviewData.content}</div>
         <motion.div
           initial={false}
           animate={{
@@ -107,16 +91,8 @@ const HospitalReview = (props: propsType) => {
           transition={{ duration: 0.3 }}
         >
           <div className={styles.detailSection}>
-            <ChipSection
-              title="사전증상"
-              items={reviewData.symptoms}
-              color="border"
-            />
-            <ChipSection
-              title="진단 내용"
-              items={reviewData.diseases}
-              color="border"
-            />
+            <ChipSection title="사전증상" items={reviewData.symptoms} color="border" />
+            <ChipSection title="진단 내용" items={reviewData.diseases} color="border" />
             <PetInfo reviewData={reviewData} />
           </div>
         </motion.div>
@@ -125,13 +101,13 @@ const HospitalReview = (props: propsType) => {
         </div>
         <div className={styles.imagesContainer}>
           {reviewData.images.map((image, index) => (
-            <Image
+            <LazyImage
               key={`${image}-${index}`}
               className={styles.reviewImage}
               src={image}
               alt="Post image"
-              width={76}
-              height={76}
+              width={"7.6rem"}
+              height={"7.6rem"}
               onClick={() => handleImageClick(index)}
             />
           ))}

--- a/src/shared/component/SearchHospital/Card.css.ts
+++ b/src/shared/component/SearchHospital/Card.css.ts
@@ -53,7 +53,5 @@ export const address = style([
 ]);
 
 export const img = style({
-  width: "7.6rem",
-  height: "7.6rem",
   borderRadius: "8px",
 });

--- a/src/shared/component/SearchHospital/Card.tsx
+++ b/src/shared/component/SearchHospital/Card.tsx
@@ -3,6 +3,7 @@ import * as styles from "./Card.css";
 import Image from "next/image";
 import nicknameCoco from "@asset/image/nicknameCoco.png";
 import Radio from "@common/component/Radio/Radio";
+import LazyImage from "@common/component/LazyImage";
 
 type CardProps = {
   id: number;
@@ -23,7 +24,13 @@ const Card = ({ id, name, address, selected, imgSrc, onSelect }: CardProps) => {
           <span className={styles.address}>{address}</span>
         </div>
       </div>
-      <Image src={imgSrc ?? nicknameCoco} alt="hospital-exterior" className={styles.img} />
+      <LazyImage
+        src={imgSrc ?? nicknameCoco}
+        alt="hospital-exterior"
+        className={styles.img}
+        width="7.6rem"
+        height="7.6rem"
+      />
     </div>
   );
 };

--- a/src/style/global.css.ts
+++ b/src/style/global.css.ts
@@ -1,6 +1,8 @@
 import "./reset.css";
 import { globalStyle } from "@vanilla-extract/css";
 
+export const sizeOfRem = 10;
+
 globalStyle("html", {
   display: "flex",
   justifyContent: "center",
@@ -9,11 +11,11 @@ globalStyle("html", {
   WebkitTouchCallout: "none",
   WebkitUserSelect: "none",
 
-  fontSize: "10px", //default
+  fontSize: `${sizeOfRem}px`, //default
 
   "@media": {
-    "(min-width: 450px) and (max-width: 600px)": { fontSize: "10px" },
-    "(max-width: 450px)": { fontSize: "10px" }, //62.5%
+    "(min-width: 450px) and (max-width: 600px)": { fontSize: `${sizeOfRem}px` },
+    "(max-width: 450px)": { fontSize: `${sizeOfRem}px` }, //62.5%
   },
 });
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #458 

## ✅ 작업 리스트

- [x] Next Image 최적화 허용할 도메인 설정
- [x] LazyImage 컴포넌트 구현
- [x] 메인캐러셀을 제외하고 모든 Image 컴포넌트 LazyImage 컴포넌트로 교체

## 🔧 작업 내용
현재 과도하게 큰 용량의 이미지가 넘어오고 있어요.
이로 인해 이미지 로딩 속도가 상당 부분 저하되고 있고, 네트워크 트래픽도 많이 사용해요.

따라서 이미지 리사이징 작업을 통해 이미지 로딩 속도를 개선해요.
저희는 Next를 사용하고 있으니 Next에서 자체적으로 제공하는 기능을 활용했어요.

또한 모든 팀원분들이 앞으로 리사이징된 이미지를 적용하도록 LazyImage 컴포넌트를 제작했어요.
앞으로 이미지 컴포넌트는 모두 LazyImage를 사용부탁드려요!

(추가로, 메인캐러셀을 제외하고 모든 이미지 컴포넌트를 리팩토링했으니 다들 확인부탁드려요)


## 📣 리뷰어에게
1. LazyImage 컴포넌트는 기존 Image 컴포넌트를 사용하던대로 사용하면 돼요. (단, width/height에는 rem,% 값만 넣을 수 있어요)
**다만, LazyImage에 제공하는 width, height 값은 스타일에도 그대로 적용돼요!** 
(따라서 width, height값만 지정하는 경우 굳이 클래스를 넣어주지 않아도 돼요. 넣어주면 중복할 뿐이에요)

2. to. @Leeyoonji23 
mainCarousel 에서 사용하고 있는 부분만 여전히 Image로 남겨두었어요. 반응형 작업을 해주고 있기 때문이에요. 
해당 PR이 머지되면, 해당 Image 컴포넌트도 LazyImage로 수정부탁드려요! 

3. 앞으로 LazyImage로 통일할게요. Image 컴포넌트 사용은 가급적 지양해주세요. 

## 📸 스크린샷 / GIF / Link

## 이미지 리사이징 결과
**이미지 총 사이즈 92.73% 감소**

as-is
<img width="395" height="249" alt="image" src="https://github.com/user-attachments/assets/3c6ee793-9a9d-4a0b-8a0c-8a62330e37d7" />

to-be
<img width="385" height="249" alt="image" src="https://github.com/user-attachments/assets/f3f467f9-fa6a-4395-957c-5d04300f8fb2" />

