### PR TITLE
[Feat/#471] scale 조정 안되도록 수정, Input 수정

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,15 +1,18 @@
 //cocos 화이팅!
-import React from 'react';
-import { Html, Head, Main, NextScript } from 'next/document';
-import Script from 'next/script';
+import React from "react";
+import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
 export default function Document() {
   return (
-    <Html lang="ko" style={{ scrollbarWidth: 'none' }}>
+    <Html lang="ko" style={{ scrollbarWidth: "none" }}>
       <Head>
         <meta charSet="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/cocos2.svg" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+        />
         <title>코코스</title>
       </Head>
       <body>
@@ -23,4 +26,4 @@ export default function Document() {
       </body>
     </Html>
   );
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,27 @@
 import { ReactNode } from "react";
 import "@style/global.css.ts";
 import Provider from "./Provider";
-import { Metadata } from "next";
+import { Metadata, Viewport } from "next";
 import { GoogleTagManager } from "@next/third-parties/google";
 
 // Metadata는 서버 컴포넌트에서만 사용 가능합니다.
 // 이 파일은 이제 클라이언트 컴포넌트이므로 메타데이터 정의를 제거합니다.
 export const metadata: Metadata = {
   title: "코코스",
-  description: "반려동물 증상을 겪는 반려인들이 고민을 공유하고 병원 정보를 확인할 수 있는 서비스",
+  description:
+    "반려동물 증상을 겪는 반려인들이 고민을 공유하고 병원 정보를 확인할 수 있는 서비스",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
 };
 
 // 클라이언트 컴포넌트에서는 getServerSideProps나 metadata 등 서버 기능을 사용할 수 없습니다.
-export default function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko" style={{ scrollbarWidth: "none" }}>
       <GoogleTagManager gtmId="GTM-MMTW28DS" />

--- a/src/common/component/TextField/index.tsx
+++ b/src/common/component/TextField/index.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import React from "react";
-import { clearButton, iconstyle, InputVariants, styles, WrapVariants } from "@common/component/TextField/styles.css.ts";
+import {
+  iconstyle,
+  InputVariants,
+  leftIconStyle,
+  styles,
+  WrapVariants,
+} from "@common/component/TextField/styles.css.ts";
 import { IcClear } from "@asset/svg";
 
 interface TextFieldProps {
@@ -65,7 +71,7 @@ export const TextField = React.forwardRef<HTMLInputElement, propsType>(
     return (
       <div className={styles.wrapper({ state, active })} onClick={onClick}>
         <div className={styles.leftWrap()}>
-          {leftIcon && <p className={iconstyle}>{leftIcon}</p>}
+          {leftIcon && <p className={leftIconStyle}>{leftIcon}</p>}
           <span className={styles.mention}>{mentionedNickname}</span>
           <input
             ref={ref}
@@ -83,7 +89,7 @@ export const TextField = React.forwardRef<HTMLInputElement, propsType>(
           />
         </div>
         {value && isDelete ? (
-          <button onClick={onClearClick} className={clearButton}>
+          <button onClick={onClearClick} className={iconstyle}>
             <IcClear height={20} width={20} />
           </button>
         ) : (

--- a/src/common/component/TextField/index.tsx
+++ b/src/common/component/TextField/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { iconstyle, InputVariants, styles, WrapVariants } from "@common/component/TextField/styles.css.ts";
+import { clearButton, iconstyle, InputVariants, styles, WrapVariants } from "@common/component/TextField/styles.css.ts";
 import { IcClear } from "@asset/svg";
 
 interface TextFieldProps {
@@ -83,7 +83,7 @@ export const TextField = React.forwardRef<HTMLInputElement, propsType>(
           />
         </div>
         {value && isDelete ? (
-          <button onClick={onClearClick}>
+          <button onClick={onClearClick} className={clearButton}>
             <IcClear height={20} width={20} />
           </button>
         ) : (

--- a/src/common/component/TextField/styles.css.ts
+++ b/src/common/component/TextField/styles.css.ts
@@ -137,21 +137,19 @@ export const styles = {
   ]),
 };
 
-export const clearButton = style({
-  background: "transparent",
-  border: "none",
-  padding: 0,
-  cursor: "pointer",
-  height: "2rem",
-});
-
 export const iconstyle = style({
   height: "2rem",
   width: "2rem",
   display: "flex",
   alignContent: "center",
-  marginRight: "1rem",
 });
+
+export const leftIconStyle = style([
+  iconstyle,
+  {
+    marginRight: "1rem",
+  },
+]);
 
 export type WrapVariants = RecipeVariants<typeof styles.wrapper>;
 export type InputVariants = RecipeVariants<typeof styles.input>;

--- a/src/common/component/TextField/styles.css.ts
+++ b/src/common/component/TextField/styles.css.ts
@@ -6,11 +6,12 @@ export const styles = {
   wrapper: recipe({
     base: {
       width: "100%",
+      height: "4rem",
       display: "flex",
       justifyContent: "space-between",
       gap: "1rem",
       alignItems: "center",
-      padding: "1rem 1.8rem",
+      padding: "1rem 2rem",
       border: `0.1rem solid ${color.gray.gray200}`,
       borderRadius: "8px",
       background: color.gray.gray000,
@@ -70,9 +71,9 @@ export const styles = {
     base: [
       font.body01,
       {
-        letterSpacing: "-0.28px",
         fontWeight: 500,
-        height: "auto",
+        height: "20px",
+        lineHeight: "20px",
         minWidth: "100%",
         maxWidth: "100%",
         color: color.gray.gray900,
@@ -135,6 +136,14 @@ export const styles = {
     },
   ]),
 };
+
+export const clearButton = style({
+  background: "transparent",
+  border: "none",
+  padding: 0,
+  cursor: "pointer",
+  height: "2rem",
+});
 
 export const iconstyle = style({
   height: "2rem",


### PR DESCRIPTION
## 🔥 Related Issues

- close #471

## ✅ 작업 리스트

- [x] scale 조정 안되도록 수정
- [x] Input x 버튼 가운데로 맞추면서 높이 수정

## 🔧 작업 내용

###  scale 조정 안되도록 수정

유저가 작성할 때 input 에서 확대가 되지 않도록 수정했어요. 
컴퓨터로는 재현이 불가능하고 핸드폰으로만 확인이 가능해서 영상 첨부합니다. 

[as-is]

https://github.com/user-attachments/assets/15cf1060-b4d3-403b-b1ce-3853c0f3cd7e


[to-be] 

https://github.com/user-attachments/assets/8f07fb06-6505-420f-bd86-ba8ed6aeabeb

###  Input x 버튼 가운데로 맞추면서 높이 수정

피그마 에 있는 것을 기반으로 똑같이 반영되도록 수정했어요. 
높이와 padding 위주로 수정되었습니다. 
X 버튼이 묘하게 위로 치우진다는 QA 를 커버하기 위해 center 정렬도 해두었어요.

